### PR TITLE
Turn off cache for fits operations on URLs

### DIFF
--- a/DP0.2/02c_Image_Queries_with_TAP.ipynb
+++ b/DP0.2/02c_Image_Queries_with_TAP.ipynb
@@ -1397,7 +1397,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "hdulist = fits.open(image_url)\n",
+    "hdulist = fits.open(image_url, cache=False)\n",
     "for hdu in hdulist:\n",
     "    print(hdu.name)"
    ]
@@ -1530,7 +1530,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "img_data = fits.getdata(image_url)"
+    "img_data = fits.getdata(image_url, cache=False)"
    ]
   },
   {
@@ -1710,7 +1710,7 @@
     "        dl_results = DatalinkResults.from_result_url(result['access_url'],\n",
     "                                                     session=auth_session)\n",
     "        image_url = dl_results['access_url'][0]\n",
-    "        hdulist = fits.open(image_url)\n",
+    "        hdulist = fits.open(image_url, cache=False)\n",
     "        img_hdr = hdulist[1].header\n",
     "        img_wcs = WCS(img_hdr)\n",
     "        print(r, img_wcs.footprint_contains(targetCoord))\n",


### PR DESCRIPTION
Because the URLs in question are ultimately ephemeral Google S3 signed URLs, there will never be a cache hit and the astropy cache will grow 100MB per call, forever.  This is not helpful, so disable astropy caching when opening these URLs.