### PR TITLE
Tickets/sp 1960

### DIFF
--- a/DP0.2/01_Introduccion_a_DP02_ES.ipynb
+++ b/DP0.2/01_Introduccion_a_DP02_ES.ipynb
@@ -10,8 +10,8 @@
     "<img align=\"left\" src = https://project.lsst.org/sites/default/files/Rubin-O-Logo_0.png width=250 style=\"padding: 10px\"> \n",
     "<br><b>Introducción a Jupyter Notebooks para Data Preview 0.2</b> <br>\n",
     "Autoría: Melissa Graham <br>\n",
-    "Última verificación de ejecución: 2025-03-06 <br>\n",
-    "Versión de las Pipelines Científicas de LSST: Weekly 2025_09 <br>\n",
+    "Última verificación de ejecución: 2025-04-30 <br>\n",
+    "Versión de las Pipelines Científicas de LSST: Weekly 2025_17 <br>\n",
     "Tamaño del contenedor (Container size): medium <br>\n",
     "Nivel de aprendizaje: principiante <br>\n",
     "<br>\n",
@@ -1032,7 +1032,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.9"
+   "version": "3.12.10"
   },
   "toc-autonumbering": false
  },

--- a/DP0.2/01_Introduction_to_DP02.ipynb
+++ b/DP0.2/01_Introduction_to_DP02.ipynb
@@ -10,8 +10,8 @@
     "<img align=\"left\" src = https://project.lsst.org/sites/default/files/Rubin-O-Logo_0.png width=250 style=\"padding: 10px\"> \n",
     "<br><b>Introduction to Jupyter Notebooks for Data Preview 0.2</b> <br>\n",
     "Contact author: Melissa Graham <br>\n",
-    "Last verified to run: 2025-03-06 <br>\n",
-    "LSST Science Pipelines version: Weekly 2025_09 <br>\n",
+    "Last verified to run: 2025-04-30 <br>\n",
+    "LSST Science Pipelines version: Weekly 2025_17 <br>\n",
     "Container size: medium <br>\n",
     "Targeted learning level: beginner <br>"
    ]
@@ -1024,7 +1024,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.9"
+   "version": "3.12.10"
   },
   "toc-autonumbering": false
  },

--- a/DP0.2/02a_Introduction_to_TAP.ipynb
+++ b/DP0.2/02a_Introduction_to_TAP.ipynb
@@ -9,8 +9,8 @@
     "<img align=\"left\" src = https://project.lsst.org/sites/default/files/Rubin-O-Logo_0.png width=250 style=\"padding: 10px\"> \n",
     "<br>\n",
     "Contact authors: Leanne Guy, Melissa Graham <br>\n",
-    "Last verified to run: 2025-03-06 <br>\n",
-    "LSST Science Pipelines version: Weekly 2025_09 <br>\n",
+    "Last verified to run: 2025-04-30 <br>\n",
+    "LSST Science Pipelines version: Weekly 2025_17 <br>\n",
     "Container Size: medium <br>\n",
     "Targeted learning level: beginner <br>"
    ]
@@ -1697,7 +1697,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.9"
+   "version": "3.12.10"
   }
  },
  "nbformat": 4,

--- a/DP0.2/02b_Catalog_Queries_with_TAP.ipynb
+++ b/DP0.2/02b_Catalog_Queries_with_TAP.ipynb
@@ -9,8 +9,8 @@
     "<img align=\"left\" src = https://project.lsst.org/sites/default/files/Rubin-O-Logo_0.png width=250 style=\"padding: 10px\">\n",
     "<br>\n",
     "Contact authors: Leanne Guy and Melissa Graham <br>\n",
-    "Last verified to run: 2025-03-06 <br>\n",
-    "LSST Science Pipelines version: Weekly 2025_09 <br>\n",
+    "Last verified to run: 2025-04-30 <br>\n",
+    "LSST Science Pipelines version: Weekly 2025_17 <br>\n",
     "Container Size: medium <br>\n",
     "Targeted learning level: intermediate <br>"
    ]
@@ -2012,7 +2012,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.9"
+   "version": "3.12.10"
   }
  },
  "nbformat": 4,

--- a/DP0.2/02c_Image_Queries_with_TAP.ipynb
+++ b/DP0.2/02c_Image_Queries_with_TAP.ipynb
@@ -10,8 +10,8 @@
     "<img align=\"left\" src = https://project.lsst.org/sites/default/files/Rubin-O-Logo_0.png width=250 style=\"padding: 10px\" alt=\"Rubin Observatory logo, a graphical representation of turning stars into data.\">\n",
     "<br>\n",
     "Contact author: Melissa Graham <br>\n",
-    "Last verified to run: 2025-03-06 <br>\n",
-    "LSST Science Piplines version: Weekly 2025_09 <br>\n",
+    "Last verified to run: 2025-04-30 <br>\n",
+    "LSST Science Pipelines version: Weekly 2025_17 <br>\n",
     "Container Size: medium <br>\n",
     "Targeted learning level: intermediate <br>"
    ]
@@ -2133,7 +2133,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.9"
+   "version": "3.12.10"
   }
  },
  "nbformat": 4,

--- a/DP0.2/03a_Image_Display_and_Manipulation.ipynb
+++ b/DP0.2/03a_Image_Display_and_Manipulation.ipynb
@@ -9,8 +9,8 @@
     "<img align=\"left\" src = https://project.lsst.org/sites/default/files/Rubin-O-Logo_0.png width=250 style=\"padding: 10px\"> \n",
     "<br>\n",
     "Contact authors: Alex Drlica-Wagner, Jeff Carlin <br>\n",
-    "Last verified to run: 2025-03-06 <br>\n",
-    "LSST Science Pipelines version: Weekly 2025_09 <br>\n",
+    "Last verified to run: 2025-04-30 <br>\n",
+    "LSST Science Pipelines version: Weekly 2025_17 <br>\n",
     "Container Size: medium <br>\n",
     "Targeted learning level: beginner <br>"
    ]
@@ -1464,7 +1464,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.9"
+   "version": "3.12.10"
   },
   "livereveal": {
    "scroll": true,

--- a/DP0.2/03b_Image_Display_with_Firefly.ipynb
+++ b/DP0.2/03b_Image_Display_with_Firefly.ipynb
@@ -9,8 +9,8 @@
     "<img align=\"left\" src = https://project.lsst.org/sites/default/files/Rubin-O-Logo_0.png width=250 style=\"padding: 10px\"> \n",
     "<br>\n",
     "Contact author: Jeff Carlin<br>\n",
-    "Last verified to run: 2025-03-06 <br>\n",
-    "LSST Science Pipelines version: Weekly 2025_09 <br>\n",
+    "Last verified to run: 2025-04-30 <br>\n",
+    "LSST Science Pipelines version: Weekly 2025_17 <br>\n",
     "Container Size: medium <br>\n",
     "Targeted learning level: beginner <br>"
    ]
@@ -868,7 +868,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.9"
+   "version": "3.12.10"
   }
  },
  "nbformat": 4,

--- a/DP0.2/03c_Big_deepCoadd_Cutout.ipynb
+++ b/DP0.2/03c_Big_deepCoadd_Cutout.ipynb
@@ -10,8 +10,8 @@
     "<img align=\"left\" src = https://project.lsst.org/sites/default/files/Rubin-O-Logo_0.png width=250 style=\"padding: 10px\" alt=\"Rubin Observatory logo, a graphical representation of turning stars into data.\">\n",
     "<br>\n",
     "Contact authors: Christina Williams, Melissa Graham <br>\n",
-    "Last verified to run: 2025-03-06 <br>\n",
-    "LSST Science Pipelines version: Weekly 2025_09 <br>\n",
+    "Last verified to run: 2025-04-30 <br>\n",
+    "LSST Science Pipelines version: Weekly 2025_17 <br>\n",
     "Container Size: Large <br>\n",
     "Targeted learning level: Intermediate <br>"
    ]
@@ -1357,7 +1357,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.9"
+   "version": "3.12.10"
   }
  },
  "nbformat": 4,

--- a/DP0.2/03c_Big_deepCoadd_Cutout.ipynb
+++ b/DP0.2/03c_Big_deepCoadd_Cutout.ipynb
@@ -911,7 +911,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "newimage = getTemplateTask.run(coaddExposures=results.coaddExposures, \n",
+    "newimage = getTemplateTask.run(coaddExposureHandles=results.coaddExposures, \n",
     "                               bbox=newimage_bbox,\n",
     "                               wcs=newWCS, dataIds=results.dataIds,\n",
     "                               physical_filter='r_sim_1.4')"

--- a/DP0.2/04a_Introduction_to_the_Butler.ipynb
+++ b/DP0.2/04a_Introduction_to_the_Butler.ipynb
@@ -9,8 +9,8 @@
     "<img align=\"left\" src = https://project.lsst.org/sites/default/files/Rubin-O-Logo_0.png width=250 style=\"padding: 10px\" alt=\"Rubin Observatory logo, a graphical representation of turning stars into data.\">\n",
     "<br>\n",
     "Contact author(s): Alex Drlica-Wagner <br>\n",
-    "Last verified to run: 2025-03-06 <br>\n",
-    "LSST Science Pipelines version: Weekly 2025_09 <br>\n",
+    "Last verified to run: 2025-04-30 <br>\n",
+    "LSST Science Pipelines version: Weekly 2025_17 <br>\n",
     "Container Size: large <br>\n",
     "Targeted learning level: beginner <br>"
    ]
@@ -809,7 +809,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.9"
+   "version": "3.12.10"
   }
  },
  "nbformat": 4,

--- a/DP0.2/04b_Intermediate_Butler_Queries.ipynb
+++ b/DP0.2/04b_Intermediate_Butler_Queries.ipynb
@@ -9,8 +9,8 @@
     "<img align=\"left\" src = https://project.lsst.org/sites/default/files/Rubin-O-Logo_0.png width=250 style=\"padding: 10px\" alt=\"Rubin Observatory logo, a graphical representation of turning stars into data.\">\n",
     "<br>\n",
     "Contact author(s): Alex Drlica-Wagner, Melissa Graham <br>\n",
-    "Last verified to run: 2025-03-06 <br>\n",
-    "LSST Science Pipelines version: Weekly 2025_09 <br>\n",
+    "Last verified to run: 2025-04-30 <br>\n",
+    "LSST Science Pipelines version: Weekly 2025_17 <br>\n",
     "Container Size: medium <br>\n",
     "Targeted learning level: intermediate <br>"
    ]
@@ -1540,7 +1540,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.9"
+   "version": "3.12.10"
   }
  },
  "nbformat": 4,

--- a/DP0.2/06a_Interactive_Image_Visualization.ipynb
+++ b/DP0.2/06a_Interactive_Image_Visualization.ipynb
@@ -9,8 +9,8 @@
     "<img align=\"left\" src = https://project.lsst.org/sites/default/files/Rubin-O-Logo_0.png width=250 style=\"padding: 10px\"> \n",
     "<br>\n",
     "Contact author(s): Leanne Guy <br>\n",
-    "Last verified to run: 2025-03-06 <br>\n",
-    "LSST Science Pipelines version: Weekly 2025_09 <br>\n",
+    "Last verified to run: 2025-04-30 <br>\n",
+    "LSST Science Pipelines version: Weekly 2025_17 <br>\n",
     "Container Size: large <br>\n",
     "Targeted learning level: intermediate <br>"
    ]
@@ -870,7 +870,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.9"
+   "version": "3.12.10"
   }
  },
  "nbformat": 4,

--- a/DP0.2/06b_Interactive_Catalog_Visualization.ipynb
+++ b/DP0.2/06b_Interactive_Catalog_Visualization.ipynb
@@ -9,8 +9,8 @@
     "<img align=\"left\" src = https://project.lsst.org/sites/default/files/Rubin-O-Logo_0.png width=250 style=\"padding: 10px\"> \n",
     "<br>\n",
     "Contact author(s): Leanne Guy <br>\n",
-    "Last verified to run: 2025-03-06 <br>\n",
-    "LSST Science Pipelines version: Weekly 2025_09 <br>\n",
+    "Last verified to run: 2025-04-30 <br>\n",
+    "LSST Science Pipelines version: Weekly 2025_17 <br>\n",
     "Container Size: large <br>\n",
     "Targeted learning level: intermediate <br>"
    ]
@@ -1817,7 +1817,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.9"
+   "version": "3.12.10"
   }
  },
  "nbformat": 4,

--- a/DP0.2/07a_DiaObject_Samples.ipynb
+++ b/DP0.2/07a_DiaObject_Samples.ipynb
@@ -10,8 +10,8 @@
     "<img align=\"left\" src = https://project.lsst.org/sites/default/files/Rubin-O-Logo_0.png width=250 style=\"padding: 10px\">\n",
     "<br>\n",
     "Contact author: Melissa Graham <br>\n",
-    "Last verified to run: 2025-03-06 <br>\n",
-    "LSST Science Pipelines version: Weekly 2025_09 <br>\n",
+    "Last verified to run: 2025-04-30 <br>\n",
+    "LSST Science Pipelines version: Weekly 2025_17 <br>\n",
     "Container Size: medium <br>\n",
     "Targeted learning level: intermediate <br>"
    ]
@@ -2048,7 +2048,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.9"
+   "version": "3.12.10"
   },
   "toc-autonumbering": false
  },

--- a/DP0.2/07b_Variable_Star_Lightcurves.ipynb
+++ b/DP0.2/07b_Variable_Star_Lightcurves.ipynb
@@ -10,8 +10,8 @@
     "<img align=\"left\" src = https://project.lsst.org/sites/default/files/Rubin-O-Logo_0.png width=250 style=\"padding: 10px\"> \n",
     "<br>\n",
     "Contact author(s): Jeff Carlin and Ryan Lau <br>\n",
-    "Last verified to run: 2025-03-06 <br>\n",
-    "LSST Science Pipelines version: Weekly 2025_09 <br>\n",
+    "Last verified to run: 2025-04-30 <br>\n",
+    "LSST Science Pipelines version: Weekly 2025_17 <br>\n",
     "Container Size: medium <br>\n",
     "Targeted learning level: intermediate <br>"
    ]
@@ -1406,7 +1406,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.9"
+   "version": "3.12.10"
   },
   "toc-autonumbering": false
  },

--- a/DP0.2/08_Truth_Tables.ipynb
+++ b/DP0.2/08_Truth_Tables.ipynb
@@ -10,8 +10,8 @@
     "<img align=\"left\" src = https://project.lsst.org/sites/default/files/Rubin-O-Logo_0.png width=250 style=\"padding: 10px\"> \n",
     "<br>\n",
     "Contact author: Jeff Carlin <br>\n",
-    "Last verified to run: 2025-03-06 <br>\n",
-    "LSST Science Pipelines version: Weekly 2025_09 <br>\n",
+    "Last verified to run: 2025-04-30 <br>\n",
+    "LSST Science Pipelines version: Weekly 2025_17 <br>\n",
     "Container size: medium <br>\n",
     "Targeted learning level: beginner <br>"
    ]
@@ -991,7 +991,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.9"
+   "version": "3.12.10"
   }
  },
  "nbformat": 4,

--- a/DP0.2/10_Deblender_Data_Products.ipynb
+++ b/DP0.2/10_Deblender_Data_Products.ipynb
@@ -10,8 +10,8 @@
     "<img align=\"left\" src = https://project.lsst.org/sites/default/files/Rubin-O-Logo_0.png width=250 style=\"padding: 10px\"> \n",
     "<br>\n",
     "Contact author(s): Christina Williams <br>\n",
-    "Last verified to run: 2025-03-06 <br>\n",
-    "LSST Science Pipelines version: Weekly 2025_09 <br>\n",
+    "Last verified to run: 2025-04-30 <br>\n",
+    "LSST Science Pipelines version: Weekly 2025_17 <br>\n",
     "Container Size: medium <br>\n",
     "Targeted learning level: beginner <br>"
    ]
@@ -1577,7 +1577,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.9"
+   "version": "3.12.10"
   },
   "toc-autonumbering": false
  },

--- a/DP0.2/11_User_Packages/11_Working_with_user_packages.ipynb
+++ b/DP0.2/11_User_Packages/11_Working_with_user_packages.ipynb
@@ -8,8 +8,8 @@
     "<img align=\"left\" src = https://project.lsst.org/sites/default/files/Rubin-O-Logo_0.png width=250 style=\"padding: 10px\"> \n",
     "<br><b>Working with user installed packages</b> <br>\n",
     "Contact author(s): Leanne Guy, Douglas Tucker <br>\n",
-    "Last verified to run: 2024-03-12<br>\n",
-    "LSST Science Piplines version: Weekly 2024_04<br>\n",
+    "Last verified to run: 2025-04-30<br>\n",
+    "LSST Science Pipelines version: Weekly 2025_17<br>\n",
     "Container size: medium <br>\n",
     "Targeted learning level: beginner <br>"
    ]
@@ -454,7 +454,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.7"
+   "version": "3.12.10"
   }
  },
  "nbformat": 4,

--- a/DP0.2/12a_PSF_Data_Products.ipynb
+++ b/DP0.2/12a_PSF_Data_Products.ipynb
@@ -10,8 +10,8 @@
     "<img align=\"left\" src = https://project.lsst.org/sites/default/files/Rubin-O-Logo_0.png width=250 style=\"padding: 10px\"> \n",
     "<br>\n",
     "Contact author(s): Andrés A. Plazas Malagón<br>\n",
-    "Last verified to run: 2025-03-06 <br>\n",
-    "LSST Science Pipelines version: Weekly 2025_09 <br>\n",
+    "Last verified to run: 2025-04-30 <br>\n",
+    "LSST Science Pipelines version: Weekly 2025_17 <br>\n",
     "Container size: medium <br>\n",
     "Targeted learning level: intermediate <br>"
    ]
@@ -1798,7 +1798,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.9"
+   "version": "3.12.10"
   },
   "toc-autonumbering": false
  },

--- a/DP0.2/12b_PSF_Science_Demo.ipynb
+++ b/DP0.2/12b_PSF_Science_Demo.ipynb
@@ -10,8 +10,8 @@
     "<img align=\"left\" src = https://project.lsst.org/sites/default/files/Rubin-O-Logo_0.png width=250 style=\"padding: 10px\"> \n",
     "<br>\n",
     "Contact author(s): Andrés A. Plazas Malagón<br>\n",
-    "Last verified to run:  2025-03-07 <br>\n",
-    "LSST Science Pipelines version: Weekly 2025_09 <br>\n",
+    "Last verified to run: 2025-04-30 <br>\n",
+    "LSST Science Pipelines version: Weekly 2025_17 <br>\n",
     "Container Size: medium <br>\n",
     "Targeted learning level: advanced <br>"
    ]
@@ -1451,7 +1451,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.9"
+   "version": "3.12.10"
   },
   "toc-autonumbering": false
  },

--- a/DP0.2/13a_Image_Cutout_SciDemo.ipynb
+++ b/DP0.2/13a_Image_Cutout_SciDemo.ipynb
@@ -125,6 +125,7 @@
     "import pyvo\n",
     "from pyvo.dal.adhoc import DatalinkResults, SodaQuery\n",
     "\n",
+    "import astropy\n",
     "from astropy import units as u\n",
     "from astropy.coordinates import SkyCoord, Angle\n",
     "from astropy.io import fits\n",
@@ -1054,7 +1055,7 @@
     "\n",
     "High redshift galaxies are typically small in size. For this exercise, use aperture photometry with a relatively small aperture diameter (9 pixels) in order to obtain high S/N measurements and exclude neighbors.\n",
     "\n",
-    "#### 3.1.1 Ammending a typical search because of the rarity of z~3 galaxies in the mock data.\n",
+    "#### 3.1.1 Amending a typical search because of the rarity of z~3 galaxies in the mock data.\n",
     "The mock galaxies that go into DP0.2 are created using the LSST Catalog Simulator (<a href=https://www.lsst.org/scientists/simulations/catsimcatSim>catSim</a>), and are based on an empirical model of the evolution of galaxies outlined in <a href=\"https://arxiv.org/abs/1907.06530\">Korytov et al. 2019</a>. The input model is based on realistic number densities, fluxes, and redshift distributions across cosmic time, and utilizes the UniverseMachine methodology to assign empirical properties (see <a href=\"https://arxiv.org/abs/1806.07893\">Behroozi et al. 2019</a>). \n",
     "\n",
     "Typically at any redshift, bright galaxies are rarer than faint galaxies, which are much more common. And typically in any patch of the sky, nearby galaxies will be much more common above the detection limit of a survey than distant $z\\sim3$ galaxies. This means that $z\\sim3$ galaxies that are bright enough to meet the criteria we want (G$ < 24.5$) will require a large search area to identify a statistical sample. So, in this example, we will first identify a parent sample of bright (G < 24.5) galaxies over a very large area (4 degrees) to ensure the parent sample contains enough rare distant galaxies.\n",
@@ -1233,6 +1234,29 @@
   },
   {
    "cell_type": "markdown",
+   "id": "ac0043c2-8aa1-4fa3-8d0c-2bb2271214b9",
+   "metadata": {},
+   "source": [
+    "Perform an inner join between `results3` with `results` using the `obj_objectId` and `objectId` columns to ensure the correct rows from `results3` are matched with the correct rows from `results` in the rest of this section."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "40eace2f-6234-4fcd-85cc-4d0a7f984e34",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "joined_results = astropy.table.join(results3.to_table(), results.to_table(), \n",
+    "                                    keys_left='obj_objectId',\n",
+    "                                    keys_right='objectId',\n",
+    "                                    join_type='inner')\n",
+    "\n",
+    "joined_results"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "77bda4aa-398c-47e3-957c-0d77c7b35f4c",
    "metadata": {},
    "source": [
@@ -1242,7 +1266,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "799441f5-cb29-42a9-94cb-9c345ff1818f",
+   "id": "08cce99e-f0cd-4110-b9ae-38ee24dcdff9",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1252,11 +1276,12 @@
     "    fig, axs = plt.subplots(1, len(filt), figsize=(25, 25))\n",
     "\n",
     "    for j, ax in enumerate(fig.axes):\n",
-    "        dataId_deep = {'patch': results['patch'][whlbg][i],\n",
-    "                       'tract': results['tract'][whlbg][i],\n",
+    "        \n",
+    "        dataId_deep = {'patch': joined_results['patch'][i].item(),\n",
+    "                       'tract': joined_results['tract'][i].item(),\n",
     "                       'band': filt[j]}\n",
-    "        cutout = make_image_cutout(service, results['coord_ra'][whlbg][i],\n",
-    "                                   results['coord_dec'][whlbg][i],\n",
+    "        cutout = make_image_cutout(service, joined_results['coord_ra'][i].item(),\n",
+    "                                   joined_results['coord_dec'][i].item(),\n",
     "                                   cutout_size=0.001, imtype='deepCoadd',\n",
     "                                   dataId=dataId_deep,\n",
     "                                   filename='cutout_' + filt[j] + '_'\n",
@@ -1266,7 +1291,7 @@
     "                  vmin=0, vmax=0.7, norm='linear', origin='lower')\n",
     "        ax.set_xticks([])\n",
     "        ax.set_yticks([])\n",
-    "        ax.text(.1, .9, filt[j]+'-band z=' + str(results3['ts_redshift'][i]),\n",
+    "        ax.text(.1, .9, filt[j]+'-band z=' + str(joined_results['ts_redshift'][i].item()),\n",
     "                color='white')\n",
     "        \n",
     "        del dataId_deep, cutout"

--- a/DP0.2/13a_Image_Cutout_SciDemo.ipynb
+++ b/DP0.2/13a_Image_Cutout_SciDemo.ipynb
@@ -10,8 +10,8 @@
     "<img align=\"left\" src = https://project.lsst.org/sites/default/files/Rubin-O-Logo_0.png width=250 style=\"padding: 10px\" alt=\"Rubin Observatory logo, a graphical representation of turning stars into data.\">\n",
     "<br>\n",
     "Contact author: Christina Williams <br>\n",
-    "Last verified to run: 2025-03-06 <br>\n",
-    "LSST Science Piplines version: Weekly 2025_09 <br>\n",
+    "Last verified to run: 2025-04-30 <br>\n",
+    "LSST Science Pipelines version: Weekly 2025_17 <br>\n",
     "Container Size: medium <br>\n",
     "Targeted learning level: beginner <br>"
    ]
@@ -1569,7 +1569,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.9"
+   "version": "3.12.10"
   },
   "toc-autonumbering": false
  },

--- a/DP0.2/14_Injecting_Synthetic_Sources.ipynb
+++ b/DP0.2/14_Injecting_Synthetic_Sources.ipynb
@@ -12,8 +12,8 @@
     "<img align=\"left\" src = https://project.lsst.org/sites/default/files/Rubin-O-Logo_0.png width=250 style=\"padding: 10px\" alt=\"Rubin Observatory logo, a graphical representation of turning stars into data.\">\n",
     "<br>\n",
     "Contact author: Jeff Carlin <br>\n",
-    "Last verified to run: 2025-03-06 <br>\n",
-    "LSST Science Pipelines version: Weekly 2025_09 <br>\n",
+    "Last verified to run: 2025-04-30 <br>\n",
+    "LSST Science Pipelines version: Weekly 2025_17 <br>\n",
     "Container Size: medium <br>\n",
     "Targeted learning level: advanced <br>"
    ]
@@ -1035,7 +1035,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.9"
+   "version": "3.12.10"
   },
   "toc-autonumbering": false
  },

--- a/DP0.2/15_Survey_Property_Maps.ipynb
+++ b/DP0.2/15_Survey_Property_Maps.ipynb
@@ -10,8 +10,8 @@
     "<img align=\"left\" src = https://project.lsst.org/sites/default/files/Rubin-O-Logo_0.png width=250 style=\"padding: 10px\"> \n",
     "<br>\n",
     "Contact author: Eli Rykoff <br>\n",
-    "Last verified to run: 2025-03-06 <br>\n",
-    "LSST Science Pipelines version: Weekly 2025_09 <br>\n",
+    "Last verified to run: 2025-04-30 <br>\n",
+    "LSST Science Pipelines version: Weekly 2025_17 <br>\n",
     "Container Size: large <br>\n",
     "Targeted learning level: intermediate <br>"
    ]
@@ -770,7 +770,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.9"
+   "version": "3.12.10"
   },
   "toc-autonumbering": false
  },

--- a/DP0.2/16_Galaxy_Cluster_Weak_Lensing.ipynb
+++ b/DP0.2/16_Galaxy_Cluster_Weak_Lensing.ipynb
@@ -13,8 +13,8 @@
     "For the Rubin Science Platform at data.lsst.cloud. <br>\n",
     "Data Release: DP02 <br>\n",
     "Container Size: medium <br>\n",
-    "LSST Science Pipelines version: Weekly 2025_09 <br>\n",
-    "Last verified to run: 2025-03-15 <br>\n",
+    "Last verified to run: 2025-04-30 <br>\n",
+    "LSST Science Pipelines version: Weekly 2025_17 <br>\n",
     "Contact author(s): Shenming Fu <br>"
    ]
   },
@@ -874,7 +874,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.9"
+   "version": "3.12.10"
   }
  },
  "nbformat": 4,

--- a/DP0.2/17_DiaObject_Anomaly_Detection.ipynb
+++ b/DP0.2/17_DiaObject_Anomaly_Detection.ipynb
@@ -9,8 +9,8 @@
     "<img align=\"left\" src = https://project.lsst.org/sites/default/files/Rubin-O-Logo_0.png width=250 style=\"padding: 10px\"> \n",
     "\n",
     "<br>Contact author(s): Ryan Lau <br>\n",
-    "Last verified to run: 2025-03-26 <br>\n",
-    "LSST Science Pipelines version: Weekly 2025_09 <br>\n",
+    "Last verified to run: 2025-04-30 <br>\n",
+    "LSST Science Pipelines version: Weekly 2025_17 <br>\n",
     "Container Size: medium <br>\n",
     "Targeted learning level: Intermediate <br>"
    ]
@@ -755,7 +755,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.9"
+   "version": "3.12.10"
   }
  },
  "nbformat": 4,

--- a/DP0.2/18_Galaxy_Photometry.ipynb
+++ b/DP0.2/18_Galaxy_Photometry.ipynb
@@ -13,8 +13,8 @@
     "<img align=\"left\" src = https://noirlab.edu/public/media/archives/logos/svg/logo250.svg width=250 style=\"background-color:white; padding:10px\" alt=\"Rubin Observatory logo, a graphical representation of turning stars into data.\">\n",
     "</div>\n",
     "Contact author(s): Christina Williams <br>\n",
-    "Last verified to run: 2025-04-24 <br>\n",
-    "LSST Science Pipelines version: Weekly 2025_09 <br>\n",
+    "Last verified to run: 2025-04-30 <br>\n",
+    "LSST Science Pipelines version: Weekly 2025_17 <br>\n",
     "Container Size: medium <br>"
    ]
   },
@@ -1037,7 +1037,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.9"
+   "version": "3.12.10"
   },
   "toc-autonumbering": false
  },

--- a/DP0.2/19a_Introduction_to_AI/19a_Introduction_to_AI.ipynb
+++ b/DP0.2/19a_Introduction_to_AI/19a_Introduction_to_AI.ipynb
@@ -1,0 +1,2680 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<img align=\"left\" src = https://project.lsst.org/sites/default/files/Rubin-O-Logo_0.png width=250 style=\"padding: 10px\"> \n",
+    "<br><b> Introduction to AI-based Image Classification with Pytorch</b> <br>\n",
+    "Contact author: Brian Nord <br>\n",
+    "Last verified to run: 2025-04-28 <br>\n",
+    "LSST Science Pipelines version: Weekly 2025_17 <br>\n",
+    "Container size: medium <br>\n",
+    "Targeted learning level: beginner <br>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**Description:** An introduction to the classification of images with AI-based classification algorithms."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**Skills:** Examine AI training data, prepare it for a classification task, perform classification with a neural network, and examine the diagnostics of the classification task."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**LSST Data Products:** None; MNIST data"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**Packages:** numpy, matplotlib, sklearn, pytorch"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**Credits and Acknowledgments:** We thank Ryan Lau and Melissa Graham for feedback on the notebook."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**Get Support:**\n",
+    "Find DP0-related documentation and resources at <a href=\"https://dp0.lsst.io\">dp0.lsst.io</a>. Questions are welcome as new topics in the <a href=\"https://community.lsst.org/c/support/dp0\">Support - Data Preview 0 Category</a> of the Rubin Community Forum. Rubin staff will respond to all questions posted there."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Introduction\n",
+    "\n",
+    "This Jupyter Notebook introduces artificial intelligence (AI)-based image classification. It demonstrates how to perform a few key steps:\n",
+    "1. examine and prepare data for classification;\n",
+    "2. train an AI algorithm;\n",
+    "3. plot diagnostics of the training performance;\n",
+    "4. initially assess those diagnostics.\n",
+    "\n",
+    "\n",
+    "In this section, you will find:\n",
+    "1. a general definition of AI;\n",
+    "3. commentary on terminology in AI;\n",
+    "4. a description of the software and data used in this tutorial;\n",
+    "4. package imports;\n",
+    "5. function definitions;\n",
+    "6. definition of paths for data and figures."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 1.1. Definition of AI\n",
+    "\n",
+    "AI is a class of algorithms for building statistical models. These algorithms primarily use data for training, as opposed to models that use analytic formulae or models that are based on physical reasoning. Machine learning is a subclass of algorithms -- e.g., random forests. Deep learning is a subclass of algorithms -- e.g., neural networks. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 1.2. AI is math, not magic.\n",
+    "\n",
+    "AI is firmly based in math, computer science, and statistics. Additionally, some of the approaches are inspired by concepts or notions in biology (e.g., the computational neuron) and in physics (e.g., the Reverse Boltzmann Machine). \n",
+    "\n",
+    "Much of the jargon in AI is anthropomorphic, which can make it appear that some other than math is happening. For example, consider the following list of terms that are very often used in AI -- and what these terms actually mean mathematically.\n",
+    "\n",
+    "1. `learn` $\\rightarrow$ fit\n",
+    "2. `hallucinate`/`lie` $\\rightarrow$ predict incorrectly\n",
+    "3. `understand` $\\rightarrow$ model fit has converged\n",
+    "4. `cheat` $\\rightarrow$ more efficiently guesses the best weight parameters of the model\n",
+    "5. `believe` $\\rightarrow$ predict/infer based on statistical priors\n",
+    "\n",
+    "When we over-anthropomorphize these mathematical concepts, we obfuscate how they actually work. That makes it harder to build and refine models. That is, AI models are not 'learning' or 'understanding'; they are merely large-parameter models that are being fit to data, and AI includes novel methods for that fitting process. The only learning that's happening is what humans do with these models.\n",
+    "\n",
+    "Many of the most useful AI-related terms are defined throughout this tutorial."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 1.3. Software and Data Description\n",
+    "\n",
+    "In this notebook, we use `pytorch`, which is currently the library most often used in deep learning studies. `pytorch` is among the state-of-the-art python libraries for tensor manipulation in general and neural network model development in particular. \n",
+    "\n",
+    "Instead of using DP0 data, this tutorial uses [handwritten digits AI benchmarking data from MNIST (Modified National Institute of Standards and Technology )](https://en.wikipedia.org/wiki/MNIST_database), a large database of handwritten digits that is commonly used for training and testing machine learning algorithms. The [`MNIST handwritten digits dataset`](https://ieeexplore.ieee.org/document/6296535) comprises 10 classes --- one for each digit --- where each image is a picture of the digit written by hand. This is a useful dataset for learning the basics of neural networks and other AI algorithms. MNIST is one of a few canonical AI benchmark data sets for image classification. \n",
+    "\n",
+    "Later tutorials in this series will use stars and galaxies drawn from DP0 data."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 1.4. Import packages\n",
+    "\n",
+    "[`numpy`](https://numpy.org/) is used for computations and mathematical operations on multi-dimensional arrays.\n",
+    "\n",
+    "[`pandas`](https://pandas.pydata.org/) is used to organize and manage data.\n",
+    "\n",
+    "[`matplotlib`](https://matplotlib.org/) is a plotting library. \n",
+    "\n",
+    "[`seaborn`](https://seaborn.pydata.org/) is used for visualizations.\n",
+    "\n",
+    "[`sklearn`](https://scikit-learn.org/stable/) is a library for machine learning.\n",
+    "\n",
+    "[`torch`](https://www.pytorch.org) is used for fast tensor operations --- often used for building neural network models."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "JyaaGkFE8VOl"
+   },
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "import time\n",
+    "import datetime\n",
+    "import os\n",
+    "\n",
+    "import matplotlib\n",
+    "import matplotlib.pyplot as plt\n",
+    "from matplotlib.pyplot import cm\n",
+    "from matplotlib.colors import LogNorm\n",
+    "import seaborn as sns\n",
+    "\n",
+    "from sklearn.metrics import confusion_matrix, RocCurveDisplay\n",
+    "from sklearn.preprocessing import LabelBinarizer\n",
+    "\n",
+    "import torch\n",
+    "import torch.nn as nn\n",
+    "import torch.optim as optim\n",
+    "import torch.nn.functional as F\n",
+    "import torchvision\n",
+    "from torch.utils.data import Dataset, DataLoader, Subset, random_split"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 1.5. Define functions"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The following functions are defined and used throughout this notebook. It is not necessary to understand exactly what every function does to proceed with this tutorial. Execute all cells and move on to Section 1.6."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "jupyter": {
+     "source_hidden": true
+    }
+   },
+   "outputs": [],
+   "source": [
+    "def normalizeInputs(x_temp, input_minimum, input_maximum):\n",
+    "    \"\"\"Normalize a datum that is an input to the neural network\n",
+    "\n",
+    "    Parameters\n",
+    "    ----------\n",
+    "    x_temp: `numpy.array`\n",
+    "       image data\n",
+    "    input_minimum: `float`\n",
+    "       minimum value for normalization\n",
+    "    input_maximum: `float`\n",
+    "       maximum value for normalization\n",
+    "\n",
+    "    Returns\n",
+    "    -------\n",
+    "    x_temp_norm: `numpy.array`\n",
+    "       normalized image data\n",
+    "    \"\"\"\n",
+    "    x_temp_norm = (x_temp - input_minimum)/input_maximum\n",
+    "    return x_temp_norm"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "jupyter": {
+     "source_hidden": true
+    }
+   },
+   "outputs": [],
+   "source": [
+    "def createFileUidTimestamp():\n",
+    "    \"\"\"Create a timestamp for a filename.\n",
+    "\n",
+    "    Parameters\n",
+    "    ----------\n",
+    "    None\n",
+    "\n",
+    "    Returns\n",
+    "    -------\n",
+    "    file_uid_timestamp : `string`\n",
+    "       String from date and time.\n",
+    "    \"\"\"\n",
+    "    file_uid_timestamp = datetime.datetime.now().strftime(\"%Y%m%d_%H%M%S\")\n",
+    "    return file_uid_timestamp"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "jupyter": {
+     "source_hidden": true
+    }
+   },
+   "outputs": [],
+   "source": [
+    "def createFileName(file_prefix=\"\", file_location=\"Data/Sandbox/\",\n",
+    "                   file_suffix=\"\", useuid=True, verbose=True):\n",
+    "    \"\"\"Create a file name.\n",
+    "\n",
+    "    Parameters\n",
+    "    ----------\n",
+    "    file_prefix: `string`\n",
+    "       prefix of file name\n",
+    "    file_location: `string`\n",
+    "       path to file\n",
+    "    file_suffix: `string`\n",
+    "       suffix/extension of file name\n",
+    "    useuid: 'bool'\n",
+    "       choose to use a unique id\n",
+    "    verbose: 'bool'\n",
+    "       choose to print the file name\n",
+    "\n",
+    "    Returns\n",
+    "    -------\n",
+    "    file_final: `string`\n",
+    "        filename used for saving\n",
+    "    \"\"\"\n",
+    "    if useuid:\n",
+    "        file_uid = createFileUidTimestamp()\n",
+    "    else:\n",
+    "        file_uid = \"\"\n",
+    "\n",
+    "    file_final = file_location + file_prefix + \"_\" + file_uid + file_suffix\n",
+    "\n",
+    "    if verbose:\n",
+    "        print(file_final)\n",
+    "\n",
+    "    return file_final"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "jupyter": {
+     "source_hidden": true
+    }
+   },
+   "outputs": [],
+   "source": [
+    "def plotArrayImageExamples(subset_train,\n",
+    "                           num_row=3, num_col=3,\n",
+    "                           object_index_start=0,\n",
+    "                           figsize=(7, 7),\n",
+    "                           save_file=False,\n",
+    "                           file_prefix=\"ImageExamples\",\n",
+    "                           file_location=\"./\",\n",
+    "                           file_suffix=\".png\"):\n",
+    "    \"\"\"Plot an array of examples of images and labels\n",
+    "\n",
+    "    Parameters\n",
+    "    ----------\n",
+    "    subset_train: `numpy.ndarray`\n",
+    "       training data images\n",
+    "    num_row: `int`, optional\n",
+    "       number of rows to plot\n",
+    "    num_col: `int`, optional\n",
+    "       number of columns to plot\n",
+    "    figsize: `tuple`, optional\n",
+    "       size of figure\n",
+    "    object_index_start: `int`, optional\n",
+    "       starting index for set of images to plot\n",
+    "    file_prefix: `string`, optional\n",
+    "       prefix of file name\n",
+    "    file_location: `string`, optional\n",
+    "       path to file\n",
+    "    file_suffix: `string`, optional\n",
+    "       suffix/extension of file name\n",
+    "\n",
+    "    From: https://pytorch.org/tutorials/beginner/basics/data_tutorial.html\n",
+    "\n",
+    "    Returns\n",
+    "    -------\n",
+    "    None\n",
+    "    \"\"\"\n",
+    "    labels_map = {\n",
+    "        0: \"0\",\n",
+    "        1: \"1\",\n",
+    "        2: \"2\",\n",
+    "        3: \"3\",\n",
+    "        4: \"4\",\n",
+    "        5: \"5\",\n",
+    "        6: \"6\",\n",
+    "        7: \"7\",\n",
+    "        8: \"8\",\n",
+    "        9: \"9\",\n",
+    "    }\n",
+    "\n",
+    "    figure = plt.figure(figsize=figsize)\n",
+    "\n",
+    "    for i in range(0, num_row * num_col):\n",
+    "        sample_idx = object_index_start + i\n",
+    "        img, label = subset_train[sample_idx]\n",
+    "        figure.add_subplot(num_row, num_col, i + 1)\n",
+    "        plt.title(\"label (digit): \" + labels_map[label])\n",
+    "        plt.axis(\"off\")\n",
+    "        plt.imshow(img.squeeze(), cmap=\"gray\")\n",
+    "\n",
+    "    plt.tight_layout()\n",
+    "\n",
+    "    if save_file:\n",
+    "        file_final = createFileName(file_prefix=file_prefix,\n",
+    "                                    file_location=file_location,\n",
+    "                                    file_suffix=file_suffix,\n",
+    "                                    useuid=True)\n",
+    "        plt.savefig(file_final, bbox_inches='tight')\n",
+    "\n",
+    "    plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "jupyter": {
+     "source_hidden": true
+    }
+   },
+   "outputs": [],
+   "source": [
+    "def plotArrayHistogramExamples(subset_train,\n",
+    "                               num_row=3, num_col=3,\n",
+    "                               n_bins=10,\n",
+    "                               object_index_start=0,\n",
+    "                               figsize=(7, 7),\n",
+    "                               save_file=False,\n",
+    "                               file_prefix=\"HistogramExamples\",\n",
+    "                               file_location=\"./\",\n",
+    "                               file_suffix=\".png\"):\n",
+    "    \"\"\"Plot histograms of image pixel values\n",
+    "\n",
+    "    Parameters\n",
+    "    ----------\n",
+    "    subset_train: `numpy.ndarray`\n",
+    "       training data images\n",
+    "    num_row: `int`, optional\n",
+    "       number of rows to plot\n",
+    "    num_col: `int`, optional\n",
+    "       number of columns to plot\n",
+    "    n_bins: `int`, optional\n",
+    "       number of bins in histogram \n",
+    "    object_index_start: `int`, optional\n",
+    "       starting index for set of images to plot\n",
+    "    figsize: `tuple`, optional\n",
+    "       size of figure\n",
+    "    file_prefix: `string`, optional\n",
+    "       prefix of file name\n",
+    "    file_location: `string`, optional\n",
+    "       path to file\n",
+    "    file_suffix: `string`, optional\n",
+    "       suffix/extension of file name\n",
+    "\n",
+    "    Returns\n",
+    "    -------\n",
+    "    None\n",
+    "    \"\"\"\n",
+    "    labels_map = {\n",
+    "        0: \"0\",\n",
+    "        1: \"1\",\n",
+    "        2: \"2\",\n",
+    "        3: \"3\",\n",
+    "        4: \"4\",\n",
+    "        5: \"5\",\n",
+    "        6: \"6\",\n",
+    "        7: \"7\",\n",
+    "        8: \"8\",\n",
+    "        9: \"9\",\n",
+    "    }\n",
+    "\n",
+    "    fig, axes = plt.subplots(num_row, num_col,\n",
+    "                             figsize=figsize)\n",
+    "\n",
+    "    for i in range(0, num_row * num_col):\n",
+    "        sample_idx = object_index_start + i\n",
+    "        img, label = subset_train[sample_idx]\n",
+    "        ax = axes[i//num_col, i%num_col]\n",
+    "        img_temp = img[0, :, :]\n",
+    "        img_temp = np.array(img_temp).flat\n",
+    "        ax.hist(img_temp, bins=n_bins, color='gray')\n",
+    "        ax.set_title(\"label (digit): \" + labels_map[label])\n",
+    "        ax.set_xlabel(\"Pixel Values\")\n",
+    "\n",
+    "    plt.tight_layout()\n",
+    "\n",
+    "    if save_file:\n",
+    "        file_final = createFileName(file_prefix=file_prefix,\n",
+    "                                    file_location=file_location,\n",
+    "                                    file_suffix=file_suffix,\n",
+    "                                    useuid=True)\n",
+    "        plt.savefig(file_final, bbox_inches='tight')\n",
+    "\n",
+    "    plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "jupyter": {
+     "source_hidden": true
+    }
+   },
+   "outputs": [],
+   "source": [
+    "def predict(dataloader, model, dataset_type):\n",
+    "    \"\"\"Predict labels of inputs\n",
+    "\n",
+    "    Parameters\n",
+    "    ----------\n",
+    "    dataloader: `numpy.ndarray`\n",
+    "       training data images\n",
+    "    model: `int`, optional\n",
+    "       number of rows to plot\n",
+    "    dataset_type: `int`, optional\n",
+    "       number of columns to plot\n",
+    "\n",
+    "    Returns\n",
+    "    -------\n",
+    "    y_prob_list: `numpy.ndarray`\n",
+    "       probabilities for each class for each input\n",
+    "    y_choice_list: `numpy.ndarray`\n",
+    "       highest-probability class for each input\n",
+    "    y_true_list: `numpy.ndarray`\n",
+    "       true class for each input\n",
+    "    x_list: `numpy.ndarray`\n",
+    "       input\n",
+    "    \"\"\"\n",
+    "    size = len(dataloader.dataset)\n",
+    "    num_batches = len(dataloader)\n",
+    "    model.eval()\n",
+    "\n",
+    "    y_prob_list = []\n",
+    "    y_choice_list = []\n",
+    "    y_true_list = []\n",
+    "    x_list = []\n",
+    "\n",
+    "    i = 0\n",
+    "    loss, accuracy = 0, 0\n",
+    "    with torch.no_grad():\n",
+    "        for inputs, labels in dataloader:\n",
+    "            inputs = inputs.to(device)\n",
+    "            labels = labels.to(device)\n",
+    "\n",
+    "            y = model(inputs)\n",
+    "            y_prob = torch.softmax(y, dim=1)\n",
+    "            y_choice = (torch.max(torch.exp(y), 1)[1]).data.cpu().numpy()\n",
+    "\n",
+    "            loss += loss_fn(y, labels).item()\n",
+    "            loss /= num_batches\n",
+    "            accuracy_temp = y.argmax(1) == labels\n",
+    "            accuracy += accuracy_temp.type(torch.float).sum().item()\n",
+    "            accuracy /= size\n",
+    "\n",
+    "            y_prob_list.append(y_prob.detach())\n",
+    "            y_choice_list.append(y_choice)\n",
+    "            y_true_list.append(labels)\n",
+    "            x_list.append(inputs)\n",
+    "            labels = labels.data.cpu().numpy()\n",
+    "\n",
+    "            i += 1\n",
+    "\n",
+    "        y_prob_list = np.array(y_prob_list)\n",
+    "        y_choice_list = np.array(y_choice_list)\n",
+    "        y_true_list = np.array(y_true_list)\n",
+    "        x_list = np.array(x_list)\n",
+    "\n",
+    "        y_prob_list = np.squeeze(y_prob_list)\n",
+    "        y_choice_list = np.squeeze(y_choice_list)\n",
+    "        y_true_list = np.squeeze(y_true_list)\n",
+    "        x_list = np.squeeze(x_list)\n",
+    "\n",
+    "        print(f\"{dataset_type : <10} data set ...\\\n",
+    "             Accuracy: {(100*accuracy):>0.1f}%, Avg loss: {loss:>8f}\")\n",
+    "\n",
+    "    return y_prob_list, y_choice_list, y_true_list, x_list"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "jupyter": {
+     "source_hidden": true
+    }
+   },
+   "outputs": [],
+   "source": [
+    "def plotPredictionHistogram(y_prediction_a, y_prediction_b=None,\n",
+    "                            y_prediction_c=None, n_classes=None,\n",
+    "                            n_objects_a=None, n_colors=None,\n",
+    "                            title_a=None, title_b=None,\n",
+    "                            title_c=None, label_a=None,\n",
+    "                            label_b=None, label_c=None,\n",
+    "                            alpha=1.0, figsize=(12, 5),\n",
+    "                            save_file=False,\n",
+    "                            file_prefix=\"prediction_histogram\",\n",
+    "                            file_location=\"./\",\n",
+    "                            xlabel_plot=\"Class label\",\n",
+    "                            file_suffix=\".png\"):\n",
+    "    \"\"\"Plot histogram of predicted labels\n",
+    "\n",
+    "    Parameters\n",
+    "    ----------\n",
+    "    y_prediction_a: `numpy.ndarray`\n",
+    "    y_prediction_b: `numpy.ndarray`, optional\n",
+    "    y_prediction_c: `numpy.ndarray`, optional\n",
+    "    n_classes: `int`, optional\n",
+    "    n_objects_a: `int`, optional\n",
+    "    n_colors: `int`, optional\n",
+    "    title_a: `string`, optional\n",
+    "    title_b: `string`, optional\n",
+    "    title_c: `string`, optional\n",
+    "    label_a: `string`, optional\n",
+    "    label_b: `string`, optional\n",
+    "    label_c: `string`, optional\n",
+    "    alpha: `float`, optional\n",
+    "       transparency\n",
+    "    figsize: `tuple`, optional\n",
+    "       figure size\n",
+    "    file_prefix: `string`, optional\n",
+    "       prefix of file name\n",
+    "    file_location: `string`, optional\n",
+    "       path to file\n",
+    "    file_suffix: `string`, optional\n",
+    "       suffix/extension of file name\n",
+    "\n",
+    "    Returns\n",
+    "    -------\n",
+    "    None\n",
+    "    \"\"\"\n",
+    "    ndim = y_prediction_a.ndim\n",
+    "\n",
+    "    if ndim == 2:\n",
+    "        fig, (axa, axb, axc) = plt.subplots(1, 3, figsize=figsize)\n",
+    "        fig.subplots_adjust(wspace=0.35)\n",
+    "    elif ndim == 1:\n",
+    "        fig, ax = plt.subplots(figsize=figsize)\n",
+    "\n",
+    "    shape_a = np.shape(y_prediction_a)\n",
+    "\n",
+    "    if n_objects_a is None:\n",
+    "        n_objects_a = shape_a[0]\n",
+    "\n",
+    "    if ndim == 2:\n",
+    "        if n_classes is None:\n",
+    "            n_classes = shape_a[1]\n",
+    "        if n_colors is None:\n",
+    "            n_colors = n_classes\n",
+    "    elif ndim == 1:\n",
+    "        if n_colors is None:\n",
+    "            n_colors = 1\n",
+    "\n",
+    "    if ndim == 2:\n",
+    "        colors = cm.Purples(np.linspace(0, 1, n_colors))\n",
+    "        xlabel = \"Probability for Each Class\"\n",
+    "\n",
+    "        axa.set_ylim(0, n_objects_a)\n",
+    "        axa.set_xlabel(xlabel)\n",
+    "        axa.set_title(title_a)\n",
+    "\n",
+    "        for i in np.arange(n_classes):\n",
+    "            axa.hist(y_prediction_a[:, i], alpha=alpha,\n",
+    "                     color=colors[i], label=\"'\" + str(i) + \"'\")\n",
+    "\n",
+    "        if y_prediction_b is not None:\n",
+    "            shape_b = np.shape(y_prediction_b)\n",
+    "            axb.set_ylim(0, shape_b[0])\n",
+    "            axb.set_xlabel(xlabel)\n",
+    "            axb.set_title(title_b)\n",
+    "\n",
+    "            for i in np.arange(n_classes):\n",
+    "                axb.hist(y_prediction_b[:, i], alpha=alpha,\n",
+    "                         color=colors[i], label=\"'\" + str(i) + \"'\")\n",
+    "\n",
+    "        if y_prediction_c is not None:\n",
+    "            shape_c = np.shape(y_prediction_c)\n",
+    "            axc.set_ylim(0, shape_c[0])\n",
+    "            axc.set_xlabel(xlabel)\n",
+    "            axc.set_title(title_c)\n",
+    "\n",
+    "            for i in np.arange(n_classes):\n",
+    "                axc.hist(y_prediction_c[:, i], alpha=alpha,\n",
+    "                         color=colors[i], label=\"'\" + str(i) + \"'\")\n",
+    "\n",
+    "    elif ndim == 1:\n",
+    "        ya, xa, _ = plt.hist(y_prediction_a, alpha=alpha, color='orange',\n",
+    "                             label=label_a)\n",
+    "        y_max_list = [max(ya)]\n",
+    "\n",
+    "        if y_prediction_b is not None:\n",
+    "            yb, xb, _ = plt.hist(y_prediction_b, alpha=alpha, color='green',\n",
+    "                                 label=label_b)\n",
+    "            y_max_list.append(max(yb))\n",
+    "\n",
+    "        if y_prediction_c is not None:\n",
+    "            yc, xc, _ = plt.hist(y_prediction_c, alpha=alpha, color='purple',\n",
+    "                                 label=label_c)\n",
+    "            y_max_list.append(max(yc))\n",
+    "\n",
+    "        plt.ylim(0, np.max(y_max_list)*1.1)\n",
+    "        plt.xlabel(xlabel_plot)\n",
+    "\n",
+    "    plt.legend(loc='upper right')\n",
+    "\n",
+    "    if save_file:\n",
+    "        file_final = createFileName(file_prefix=file_prefix,\n",
+    "                                    file_location=file_location,\n",
+    "                                    file_suffix=file_suffix,\n",
+    "                                    useuid=True)\n",
+    "        plt.savefig(file_final, bbox_inches='tight')\n",
+    "\n",
+    "    plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "jupyter": {
+     "source_hidden": true
+    }
+   },
+   "outputs": [],
+   "source": [
+    "def plotTrueLabelHistogram(y_prediction_a, y_prediction_b=None,\n",
+    "                           y_prediction_c=None, n_classes=None,\n",
+    "                           n_objects_a=None, n_colors=None,\n",
+    "                           title_a=None, title_b=None,\n",
+    "                           title_c=None, label_a=None,\n",
+    "                           label_b=None, label_c=None,\n",
+    "                           alpha=1.0, figsize=(12, 5),\n",
+    "                           save_file=False,\n",
+    "                           file_prefix=\"prediction_histogram\",\n",
+    "                           file_location=\"./\",\n",
+    "                           xlabel_plot=\"Class label\",\n",
+    "                           file_suffix=\".png\"):\n",
+    "    \"\"\"Plot histogram of predicted labels\n",
+    "\n",
+    "    Parameters\n",
+    "    ----------\n",
+    "    y_prediction_a: `numpy.ndarray`\n",
+    "    y_prediction_b: `numpy.ndarray`, optional\n",
+    "    y_prediction_c: `numpy.ndarray`, optional\n",
+    "    n_classes: `int`, optional\n",
+    "    n_objects_a: `int`, optional\n",
+    "    n_colors: `int`, optional\n",
+    "    title_a: `string`, optional\n",
+    "    title_b: `string`, optional\n",
+    "    title_c: `string`, optional\n",
+    "    label_a: `string`, optional\n",
+    "    label_b: `string`, optional\n",
+    "    label_c: `string`, optional\n",
+    "    alpha: `float`, optional\n",
+    "       transparency\n",
+    "    figsize: `tuple`, optional\n",
+    "       figure size\n",
+    "    file_prefix: `string`, optional\n",
+    "       prefix of file name\n",
+    "    file_location: `string`, optional\n",
+    "       path to file\n",
+    "    file_suffix: `string`, optional\n",
+    "       suffix/extension of file name\n",
+    "\n",
+    "    Returns\n",
+    "    -------\n",
+    "    None\n",
+    "    \"\"\"\n",
+    "\n",
+    "    ndim = y_prediction_a.ndim\n",
+    "\n",
+    "    if ndim == 2:\n",
+    "        fig, (axa, axb, axc) = plt.subplots(1, 3, figsize=figsize)\n",
+    "        fig.subplots_adjust(wspace=0.35)\n",
+    "    elif ndim == 1:\n",
+    "        fig, ax = plt.subplots(figsize=figsize)\n",
+    "\n",
+    "    shape_a = np.shape(y_prediction_a)\n",
+    "\n",
+    "    if n_objects_a is None:\n",
+    "        n_objects_a = shape_a[0]\n",
+    "\n",
+    "    if ndim == 2:\n",
+    "        if n_classes is None:\n",
+    "            n_classes = shape_a[1]\n",
+    "        if n_colors is None:\n",
+    "            n_colors = n_classes\n",
+    "    elif ndim == 1:\n",
+    "        if n_colors is None:\n",
+    "            n_colors = 1\n",
+    "\n",
+    "    if ndim == 2:\n",
+    "        colors = cm.Purples(np.linspace(0, 1, n_colors))\n",
+    "        xlabel = \"Probability for Each Class\"\n",
+    "\n",
+    "        axa.set_ylim(0, n_objects_a)\n",
+    "        axa.set_xlabel(xlabel)\n",
+    "        axa.set_title(title_a)\n",
+    "\n",
+    "        for i in np.arange(n_classes):\n",
+    "            axa.hist(y_prediction_a[:, i], alpha=alpha,\n",
+    "                     color=colors[i], label=\"'\" + str(i) + \"'\")\n",
+    "\n",
+    "        if y_prediction_b is not None:\n",
+    "            shape_b = np.shape(y_prediction_b)\n",
+    "            axb.set_ylim(0, shape_b[0])\n",
+    "            axb.set_xlabel(xlabel)\n",
+    "            axb.set_title(title_b)\n",
+    "\n",
+    "            for i in np.arange(n_classes):\n",
+    "                axb.hist(y_prediction_b[:, i], alpha=alpha,\n",
+    "                         color=colors[i], label=\"'\" + str(i) + \"'\")\n",
+    "\n",
+    "        if y_prediction_c is not None:\n",
+    "            shape_c = np.shape(y_prediction_c)\n",
+    "            axc.set_ylim(0, shape_c[0])\n",
+    "            axc.set_xlabel(xlabel)\n",
+    "            axc.set_title(title_c)\n",
+    "\n",
+    "            for i in np.arange(n_classes):\n",
+    "                axc.hist(y_prediction_c[:, i], alpha=alpha,\n",
+    "                         color=colors[i], label=\"'\" + str(i) + \"'\")\n",
+    "\n",
+    "    elif ndim == 1:\n",
+    "        ya, xa, _ = plt.hist(y_prediction_a, alpha=alpha, color='orange',\n",
+    "                             label=label_a)\n",
+    "        y_max_list = [max(ya)]\n",
+    "\n",
+    "        if y_prediction_b is not None:\n",
+    "            yb, xb, _ = plt.hist(y_prediction_b, alpha=alpha, color='green',\n",
+    "                                 label=label_b)\n",
+    "            y_max_list.append(max(yb))\n",
+    "\n",
+    "        if y_prediction_c is not None:\n",
+    "            yc, xc, _ = plt.hist(y_prediction_c, alpha=alpha, color='purple',\n",
+    "                                 label=label_c)\n",
+    "            y_max_list.append(max(yc))\n",
+    "\n",
+    "        plt.ylim(0, np.max(y_max_list)*1.1)\n",
+    "        plt.xlabel(xlabel_plot)\n",
+    "\n",
+    "    plt.legend(loc='upper right')\n",
+    "\n",
+    "    if save_file:\n",
+    "        file_final = createFileName(file_prefix=file_prefix,\n",
+    "                                    file_location=file_location,\n",
+    "                                    file_suffix=file_suffix,\n",
+    "                                    useuid=True)\n",
+    "        plt.savefig(file_final, bbox_inches='tight')\n",
+    "\n",
+    "    plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "jupyter": {
+     "source_hidden": true
+    }
+   },
+   "outputs": [],
+   "source": [
+    "def plotLossHistory(history, figsize=(8, 5),\n",
+    "                    save_file=False,\n",
+    "                    file_prefix=\"prediction_histogram\",\n",
+    "                    file_location=\"./\",\n",
+    "                    file_suffix=\".png\"):\n",
+    "    \"\"\"Plot loss history of the model as function of epoch\n",
+    "\n",
+    "    Parameters\n",
+    "    ----------\n",
+    "    history: `keras.src.callbacks.history.History`\n",
+    "       keras callback history object containing the losses at each epoch\n",
+    "    figsize: `tuple`, optional\n",
+    "       figure size\n",
+    "    file_prefix: `string`, optional\n",
+    "       prefix of file name\n",
+    "    file_location: `string`, optional\n",
+    "       path to file\n",
+    "    file_suffix: `string`, optional\n",
+    "       suffix/extension of file name\n",
+    "\n",
+    "    Returns\n",
+    "    -------\n",
+    "    None\n",
+    "    \"\"\"\n",
+    "    fig, (ax1, ax2) = plt.subplots(2, 1, sharex=True, figsize=figsize)\n",
+    "\n",
+    "    loss_tra = np.array(history['loss'])\n",
+    "    loss_val = np.array(history['val_loss'])\n",
+    "    loss_dif = loss_val - loss_tra\n",
+    "\n",
+    "    ax1.plot(loss_tra, label='Training')\n",
+    "    ax1.plot(loss_val, label='Validation')\n",
+    "    ax1.legend()\n",
+    "\n",
+    "    ax2.plot(loss_dif, color='red', label='residual')\n",
+    "    ax2.axhline(y=0, color='grey', linestyle='dashed', label='zero bias')\n",
+    "    ax2.sharex(ax1)\n",
+    "    ax2.legend()\n",
+    "\n",
+    "    ax1.set_title('Loss History')\n",
+    "    ax1.set_ylabel('Loss')\n",
+    "    ax2.set_ylabel('Loss Residual')\n",
+    "    ax2.set_xlabel('Epoch')\n",
+    "    plt.tight_layout()\n",
+    "\n",
+    "    if save_file:\n",
+    "        file_final = createFileName(file_prefix=file_prefix,\n",
+    "                                    file_location=file_location,\n",
+    "                                    file_suffix=file_suffix,\n",
+    "                                    useuid=True)\n",
+    "\n",
+    "        plt.savefig(file_final, bbox_inches='tight')\n",
+    "\n",
+    "    plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "jupyter": {
+     "source_hidden": true
+    }
+   },
+   "outputs": [],
+   "source": [
+    "def plotArrayImageConfusion(x_tra, y_tra, y_pred_tra_topchoice,\n",
+    "                            title_main=None, num=10,\n",
+    "                            save_file=False,\n",
+    "                            file_prefix=\"prediction_histogram\",\n",
+    "                            file_location=\"./\",\n",
+    "                            file_suffix=\".png\"):\n",
+    "    \"\"\"Plot images of examples objects that are misclassified.\n",
+    "\n",
+    "    Parameters\n",
+    "    ----------\n",
+    "    x_tra: `numpy.ndarray`\n",
+    "       training image data\n",
+    "    y_tra: `numpy.ndarray`\n",
+    "       training label data\n",
+    "    y_pred_tra_topchoice: `numpy.ndarray`\n",
+    "       top choice of the predicted labels\n",
+    "    title_main: `string`, optional\n",
+    "       title for the plot\n",
+    "    num: `int`, optional\n",
+    "       number of examples\n",
+    "    file_prefix: `string`, optional\n",
+    "       prefix of file name\n",
+    "    file_location: `string`, optional\n",
+    "       path to file\n",
+    "    file_suffix: `string`, optional\n",
+    "       suffix/extension of file name\n",
+    "\n",
+    "    Returns\n",
+    "    -------\n",
+    "    None\n",
+    "    \"\"\"\n",
+    "    num_row = 2\n",
+    "    num_col = 5\n",
+    "    images = x_tra[:num]\n",
+    "    labels_true = y_tra[:num]\n",
+    "    labels_pred = y_pred_tra_topchoice[:num]\n",
+    "\n",
+    "    fig, axes = plt.subplots(num_row, num_col,\n",
+    "                             figsize=(1.5*num_col, 2*num_row))\n",
+    "\n",
+    "    fig.patch.set_linewidth(5)\n",
+    "    fig.patch.set_edgecolor('cornflowerblue')\n",
+    "\n",
+    "    for i in range(num):\n",
+    "        ax = axes[i//num_col, i%num_col]\n",
+    "        ax.imshow(images[i], cmap='gray')\n",
+    "        ax.set_title(r'True: {}'.format(labels_true[i]) + '\\n'\n",
+    "                     + 'Pred: {}'.format(labels_pred[i]))\n",
+    "\n",
+    "    fig.suptitle(title_main)\n",
+    "    plt.tight_layout()\n",
+    "\n",
+    "    if save_file:\n",
+    "        file_final = createFileName(file_prefix=file_prefix,\n",
+    "                                    file_location=file_location,\n",
+    "                                    file_suffix=file_suffix,\n",
+    "                                    useuid=True)\n",
+    "\n",
+    "        plt.savefig(file_final, bbox_inches='tight')\n",
+    "\n",
+    "    plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "jupyter": {
+     "source_hidden": true
+    }
+   },
+   "outputs": [],
+   "source": [
+    "def plotROCMulticlassOnevsrest(y_tra, y_tes, y_pred_tes,\n",
+    "                               figsize=(7, 7),\n",
+    "                               save_file=False,\n",
+    "                               file_prefix=\"ImageExamples\",\n",
+    "                               file_location=\"./\",\n",
+    "                               file_suffix=\".png\"):\n",
+    "    \"\"\"Plot the one-vs-rest ROC curve\n",
+    "\n",
+    "    Parameters\n",
+    "    ----------\n",
+    "    y_tra: `numpy.ndarray`\n",
+    "       training data true labels\n",
+    "    y_tes: `numpy.ndarray`\n",
+    "       testing data true labels\n",
+    "    y_pred_tes: `numpy.ndarray`\n",
+    "       testing data predicted labels\n",
+    "    figsize: `tuple`, optional\n",
+    "       size of figure\n",
+    "    file_prefix: `string`, optional\n",
+    "       prefix of file name\n",
+    "    file_location: `string`, optional\n",
+    "       path to file\n",
+    "    file_suffix: `string`, optional\n",
+    "       suffix/extension of file name\n",
+    "\n",
+    "    Returns\n",
+    "    -------\n",
+    "    None\n",
+    "    \"\"\"\n",
+    "    fig, ax = plt.subplots(figsize=figsize)\n",
+    "    n_classes = len(y_prob_tes[0])\n",
+    "    label_target_list = np.linspace(0, n_classes-1, num=n_classes)\n",
+    "    color_list = cm.rainbow(np.linspace(0, 0.5, n_classes))\n",
+    "\n",
+    "    for label_target, color in zip(label_target_list, color_list):        \n",
+    "        label_binarizer = LabelBinarizer().fit(y_tra)\n",
+    "        y_onehot_tes = label_binarizer.transform(y_tes)\n",
+    "        class_id = np.flatnonzero(label_binarizer.classes_ == label_target)[0]\n",
+    "        display = RocCurveDisplay.from_predictions(\n",
+    "            y_onehot_tes[:, class_id],\n",
+    "            y_pred_tes[:, class_id],\n",
+    "            name=f\"{int(label_target)} vs the rest\",\n",
+    "            color=color,\n",
+    "            ax=ax,\n",
+    "            plot_chance_level=(class_id == 9)\n",
+    "        )\n",
+    "        \n",
+    "    _ = display.ax_.set(\n",
+    "        xlabel=\"False Positive Rate\",\n",
+    "        ylabel=\"True Positive Rate\",\n",
+    "        title=\"ROC: One-vs-Rest\",\n",
+    "    )\n",
+    "\n",
+    "    if save_file:\n",
+    "        file_final = createFileName(file_prefix=file_prefix,\n",
+    "                                    file_location=file_location,\n",
+    "                                    file_suffix=file_suffix,\n",
+    "                                    useuid=True)\n",
+    "        plt.savefig(file_final, bbox_inches='tight')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "jupyter": {
+     "source_hidden": true
+    }
+   },
+   "outputs": [],
+   "source": [
+    "def plotArrayHistogramConfusion(x_tra, y_tra, y_pred_tra_topchoice,\n",
+    "                                title_main=None, num=10,\n",
+    "                                save_file=False,\n",
+    "                                file_prefix=\"prediction_histogram\",\n",
+    "                                file_location=\"./\",\n",
+    "                                file_suffix=\".png\"):\n",
+    "    \"\"\"Plot histograms of pixel values for images that are misclassified.\n",
+    "\n",
+    "    Parameters\n",
+    "    ----------\n",
+    "    x_tra: `numpy.ndarray`\n",
+    "       training image data\n",
+    "    y_tra: `numpy.ndarray`\n",
+    "       training label data\n",
+    "    y_pred_tra_topchoice: `numpy.ndarray`\n",
+    "       top choice of the predicted labels\n",
+    "    title_main: `string`, optional\n",
+    "       title of plot\n",
+    "    num: `int`, optional\n",
+    "       number of examples\n",
+    "    file_prefix: `string`, optional\n",
+    "       prefix of file name\n",
+    "    file_location: `string`, optional\n",
+    "       path to file\n",
+    "    file_suffix: `string`, optional\n",
+    "       suffix/extension of file name\n",
+    "\n",
+    "    Returns\n",
+    "    -------\n",
+    "    None\n",
+    "    \"\"\"\n",
+    "    n_bins = 10\n",
+    "    num_row = 2\n",
+    "    num_col = 5\n",
+    "    images = x_tra[:num]\n",
+    "    labels_true = y_tra[:num]\n",
+    "    labels_pred = y_pred_tra_topchoice[:num]\n",
+    "\n",
+    "    fig, axes = plt.subplots(num_row, num_col,\n",
+    "                             figsize=(1.5*num_col, 2*num_row))\n",
+    "\n",
+    "    fig.patch.set_linewidth(5)\n",
+    "    fig.patch.set_edgecolor('cornflowerblue')\n",
+    "\n",
+    "    for i in range(num):\n",
+    "        ax = axes[i//num_col, i%num_col]\n",
+    "        images_temp = images[i, :, :].flat\n",
+    "        ax.hist(images_temp, bins=n_bins, color='gray')\n",
+    "        ax.set_title(r'True: {}'.format(labels_true[i]) + '\\n'\n",
+    "                     + 'Pred: {}'.format(labels_pred[i]))\n",
+    "        ax.set_xlabel('Pixel Values')\n",
+    "\n",
+    "    fig.suptitle(title_main)\n",
+    "    plt.tight_layout()\n",
+    "\n",
+    "    if save_file:\n",
+    "        file_final = createFileName(file_prefix=file_prefix,\n",
+    "                                    file_location=file_location,\n",
+    "                                    file_suffix=file_suffix,\n",
+    "                                    useuid=True)\n",
+    "\n",
+    "        plt.savefig(file_final, bbox_inches='tight')\n",
+    "\n",
+    "    plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 1.6. Define paths for data and figures"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Neural network training (i.e., model fitting) typically requires many numerical experiments to achieve an ideal model. To facilitate the comparison of these experiments/models, it is helpful to organize data carefully. \n",
+    "\n",
+    "Set the variable `run_label` for each training run. \n",
+    "Set paths for the model weight parameters and diagnostic figures, and\n",
+    "save these paths in the dictionary `path_dict` to facilitate passing information to plotting functions.\n",
+    "Check whether the paths exist, and if not, create them."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "run_label = \"Run000\"\n",
+    "\n",
+    "path_temp = os.getenv(\"HOME\") + '/dp02_19a_temp'\n",
+    "path_dict = {'run_label': run_label,\n",
+    "             'dir_data_model': path_temp + \"/Models/\",\n",
+    "             'dir_data_figures': path_temp + \"/Figures/\",\n",
+    "             'dir_data_data': path_temp + \"/Data/\",\n",
+    "             'file_model_prefix': \"Model\",\n",
+    "             'file_figure_prefix': \"Figure\",\n",
+    "             'file_figure_suffix': \".png\",\n",
+    "             'file_model_suffix': \".pt\"\n",
+    "             }\n",
+    "del path_temp\n",
+    "\n",
+    "if not os.path.exists(path_dict['dir_data_model']):\n",
+    "    os.makedirs(path_dict['dir_data_model'])\n",
+    "\n",
+    "if not os.path.exists(path_dict['dir_data_figures']):\n",
+    "    os.makedirs(path_dict['dir_data_figures'])\n",
+    "\n",
+    "if not os.path.exists(path_dict['dir_data_data']):\n",
+    "    os.makedirs(path_dict['dir_data_data'])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Load and Prepare data"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In this section, you will encounter the following items regarding the dataset that we'll build a classification model for.\n",
+    "\n",
+    "1. obtaining the data: Normalizing the data and downloading the data;\n",
+    "5. splitting the data into different sets;\n",
+    "6. creating subsets of each of those with a smaller number of objects;\n",
+    "7. examining the raw data;\n",
+    "8. creating dataloaders for model training."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 2.1. Obtain the dataset"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`pytorch` has a simple function to download the MNIST data to your local server for free. While downloading, we use the `transforms` method to normalize the data; this makes the model training more efficient."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### 2.1.1. Normalize data"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Create a `transform` that is used to convert the data sets to tensors that can be used in `pytorch`. This also transforms all the data from the range $[0,255]$ to $[0.,1.]$."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "kMzao03zcF5i",
+    "outputId": "0401d0af-d607-436a-908f-385ffc85812c"
+   },
+   "outputs": [],
+   "source": [
+    "transform = torchvision.transforms.Compose([torchvision.transforms.ToTensor()])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### 2.1.2. Download data"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Download the data from a remote reserver."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%time\n",
+    "dataset = torchvision.datasets.MNIST(root=path_dict['dir_data_data'], train=True,\n",
+    "                                     download=True, transform=transform)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 2.2. Split data into training, validation, and testing"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Split for a proper 'blind' analysis and optimization of an AI model.\n",
+    "\n",
+    "There are three primary data sets used in model development and optimization:\n",
+    "\n",
+    "* `Training` (with filename tag `_tra`) data is used directly by the algorithm to update the parameters of the AI model -- e.g., the weights of the computational neurons on the  edges in neural networks.\n",
+    "* `Validation` (`_val`)  data is used indirectly to update the hyperparameters of the AI model -- e.g., the batch size (`batchsize`), the learning rate, or the layers in the architecture of a neural network. Each time the neural network has completed training with the training data, the human looks at those diagnostics when run on the training and the validation data.\n",
+    "* `Test(ing)` (`_tes`) data is only used when the model is trained and validated and will no longer be update or further trained. This is the data that you would consider to be the new data that has not been examined before -- e.g., newly observed data that has not been previously characterized."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We use most of the data for training to maximize the accuracy and generalization of the model. We use a small amount of validation data, because only a little bit is needed to check the model optimization during training. We also use only a small amount of testing data, assuming that new data sets to examine are smaller than existing training data sets."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Set the fractions for the training, validation, and test sets."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fraction_tra = 0.8\n",
+    "fraction_val = 0.1\n",
+    "fraction_tes = 0.1"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Split the data according to those fractions."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fraction_list = [fraction_tra, fraction_val, fraction_tes]\n",
+    "\n",
+    "data_tra_full, data_val_full, data_tes_full = \\\n",
+    "    torch.utils.data.random_split(dataset, fraction_list)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Print the data set sizes to check how much data you're using to optimize the model. Each problem has a unique requirement regarding the amount of training data. It typically depends on the complexity of shapes in the images and the variation across classes. Without enough data in each class, the model will likely be at least somewhat predictive but have a sub-optimal final loss (i.e., average error). If a problem requires neural networks, then it will likely require at least hundreds of images. Also, there is an interplay between the amount of data, the complexity of the images, and the complexity and size of the model."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(\"training:\", len(data_tra_full.indices))\n",
+    "print(\"validation:\", len(data_val_full.indices))\n",
+    "print(\"test\", len(data_tes_full.indices))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 2.3. Create a subset of the training data."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Use only a subset of each data to make the training faster for this tutorial. Consider increasing the sizes of these data sets in your exploration of the tutorial elements."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "subset_size = 5000\n",
+    "\n",
+    "subset_indices_tra = np.arange(subset_size)\n",
+    "subset_indices_val = np.arange(subset_size)\n",
+    "subset_indices_tes = np.arange(subset_size)\n",
+    "\n",
+    "data_tra = Subset(data_tra_full, subset_indices_tra)\n",
+    "data_val = Subset(data_val_full, subset_indices_val)\n",
+    "data_tes = Subset(data_tes_full, subset_indices_tes)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 2.4. Examine raw data"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Review the raw data shapes by looking at a single datum in the training set. Each datum in the training set is an image-label pair. The image is a tensor, and the label is an integer. The image size in part determines the depth (number of layers) of the neural network. This will be discussed in a later section on model training."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sample_index = 0\n",
+    "image, label = data_tra[sample_index]\n",
+    "print(f\"The image shape is {image.shape}.\")\n",
+    "print(f\"The label for this image is {label}.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Print the image labels and their corresponding indices within a dataset object. This is useful for verifying that you understand your data set."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "{v: k for k, v in dataset.class_to_idx.items()}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Plot examples of the raw data."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "file_prefix = path_dict['file_figure_prefix'] + \"_\"\\\n",
+    "                                              + \"Example_Image_Array\"\\\n",
+    "                                              + \"_\" + path_dict['run_label']\n",
+    "\n",
+    "plotArrayImageExamples(data_tra,\n",
+    "                       num_row=3, num_col=3,\n",
+    "                       save_file=False,\n",
+    "                       object_index_start=0,\n",
+    "                       file_prefix=file_prefix,\n",
+    "                       file_location=path_dict['dir_data_figures'],\n",
+    "                       file_suffix=path_dict['file_figure_suffix'])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "> Figure 1: Three rows of three images, each a handwritten number in white on a black background."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Plot the distributions of pixel values to understand the data further. All pixel data has been normalized, and pixels have values between 0 and 1 only.\n",
+    "\n",
+    "The distribution of pixel values matches the images shown above: mostly black (values near 0) pixels, with some white (values near 1), and a few grey (values in between 0 and 1)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "file_prefix = path_dict['file_figure_prefix'] + \"_\"\\\n",
+    "                                              + \"Example_Histogram_Array\"\\\n",
+    "                                              + \"_\" + path_dict['run_label']\n",
+    "\n",
+    "plotArrayHistogramExamples(data_tra,\n",
+    "                           num_row=3, num_col=3,\n",
+    "                           save_file=False,\n",
+    "                           file_prefix=file_prefix,\n",
+    "                           file_location=path_dict['dir_data_figures'],\n",
+    "                           file_suffix=path_dict['file_figure_suffix'])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "> Figure 2: Three rows of three histograms, each showing the distribution of pixel values (number of pixels of a given value) for the handwritten digit images shown in Figure 1."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Examine the balance of classes in the data sets. If one class has more objects in the training set than other classes, the model will tend to be biased toward predicting that class. The classes don't have to be distributed perfectly uniformly, but a high degree of uniformity is preferable."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Use the `plotPredictionHistogram` function to plot histograms of true label distributions by class."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "y_tra = []\n",
+    "y_val = []\n",
+    "y_tes = []\n",
+    "\n",
+    "for i in np.arange(subset_size):\n",
+    "    image, label_tra = data_tra[i]\n",
+    "    image, label_val = data_val[i]\n",
+    "    image, label_tes = data_tes[i]\n",
+    "    y_tra.append(label_tra)\n",
+    "    y_val.append(label_val)\n",
+    "    y_tes.append(label_tes)\n",
+    "\n",
+    "y_tra = np.array(y_tra)\n",
+    "y_val = np.array(y_val)\n",
+    "y_tes = np.array(y_tes)\n",
+    "\n",
+    "file_prefix = path_dict['file_figure_prefix'] + \"_\"\\\n",
+    "                                              + \"Histograms_true_class\"\\\n",
+    "                                              + \"_\" + path_dict['run_label']\n",
+    "\n",
+    "plotPredictionHistogram(y_tra,\n",
+    "                        y_prediction_b=y_val,\n",
+    "                        y_prediction_c=y_tes,\n",
+    "                        label_a=\"Training Set\",\n",
+    "                        label_b=\"Validation Set\",\n",
+    "                        label_c=\"Testing Set\",\n",
+    "                        figsize=(12, 5),\n",
+    "                        alpha=0.5,\n",
+    "                        xlabel_plot=\"True class label\",\n",
+    "                        file_prefix=file_prefix,\n",
+    "                        file_location=path_dict['dir_data_figures'],\n",
+    "                        file_suffix=path_dict['file_figure_suffix'])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**Figure 3**: The histograms of true class labels for each data set. Each histogram is for a different data set used during model training --- training data, validation data, and test data. Note that these are overlapping histograms, not stacked. Please compare to Figure 4, which shows histograms of the predicted class labels."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 2.5. Create Dataloaders for training"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Set the batch size, which will be used in dataloaders and in training. To simplify data-handling, we set the batch size to the size of the subset that we select. This means that there is one batch used in training."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "batch_size = subset_size"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Create dataloaders for the training, validation, and test set data loaders."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "trainloader = torch.utils.data.DataLoader(data_tra, batch_size=batch_size,\n",
+    "                                          shuffle=False)\n",
+    "\n",
+    "validloader = torch.utils.data.DataLoader(data_val, batch_size=batch_size,\n",
+    "                                          shuffle=False)\n",
+    "\n",
+    "testloader = torch.utils.data.DataLoader(data_tes, batch_size=batch_size,\n",
+    "                                         shuffle=False)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. Train the model: Convolutional Neural Network"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In this section, you will encounter the following major items for training a neural network:\n",
+    "\n",
+    "1. basics of `pytorch` model-building;\n",
+    "2. defining the neural network model -- setting model hyperparameters, a glossary of terms of model architecture elements, glossary of terms for a network model class, creating a model class;\n",
+    "3. training the model."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 3.1. Basics of pytorch"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In `pytorch`, neural network models are defined as classes. This is slightly different than typical `tensorflow` usage, in which people build a `sequential` model or use a pre-built `model` class and add layers to that model. \n",
+    "\n",
+    "The other major difference between `pytorch` and `tensorflow` is the shape of the tensors and the inputs for each layer. \n",
+    "\n",
+    "In particular, in `pytorch` one has to explicitly match the output from one layer to the input of the next layer. Sometimes, this can be done with a calculation. But, more often, one must perform guess-and-check. <Explain this>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 3.2. Define the neural network model"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### 3.2.1. Define model hyperparameters"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Set the seed that for the random initial model weight values."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "Zsc_pqZtWftJ",
+    "outputId": "8238aa09-2afd-47ef-c93e-3910b342fe38"
+   },
+   "outputs": [],
+   "source": [
+    "seed = 1729\n",
+    "new = torch.manual_seed(seed)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Define the loss function. We choose cross-entropy, which is the standard loss function for classification of discrete labels."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "loss_fn = nn.CrossEntropyLoss()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### 3.2.2. Glossary: model architecture elements"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Below is a list of important terms for elements of a neural network architecture.\n",
+    "\n",
+    " * `activation function`: a function within a neuron that takes inputs from a previous layer and produces an output -- usually, this function is non-linear. Examples include \"sigmoid,\" \"softmax,\" and \"reLu\" (rectified linear unit).\n",
+    " * `sigmoid`: an activation function that takes points from the Real line and maps them to the range [-1,1].\n",
+    " * `softmax`: an activation function that takes points from the Real line and maps them to the range [0,1]. This can be used to obtain a 'probability score.'\n",
+    " * `ReLU (rectified linear unit)`: an activation function that non-smoothly goes from 0 to some positive Real number when a threshold is reached for the input value. \n",
+    " * `weight`: the weight factor within an activation function.\n",
+    " * `bias`: the bias factor applied after an activation function.\n",
+    " * `layer`: one set of nodes/neurons that receive input data simultaneously.\n",
+    " * `linear (Dense) layer`: occurs due to the \"flattening\" of a higher-dimensional data vector, like an image. It only has an activation function -- as opposed to a convolutional layer which makes a convolution operation.\n",
+    " * `convolutional layer`: a layer that applies a convolution operation to an input sample."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### 3.2.3. Glossary: class that defines a network model"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Typically, there are two functions within this class.\n",
+    "\n",
+    "The constructor function (`__init__`) defines the available layers of the network. These layers require specific settings related to the data set shapes. \n",
+    "* `Conv2d`: defines a two-dimensional convolutional layer. Four inputs are considered here:\n",
+    "    * `in_channels` (required): the number of input channels.\n",
+    "    * `out_channels` (required): the number of output channels.\n",
+    "    * `kernel_size` (required): the size on one dimension of the convolutional kernel.\n",
+    "    * `stride` (optional): the stride of the convolution\n",
+    "* `Dropout`: defines a dropout layer. The fraction of neuron weights that are set to zero. Typically, this is used when the model is overfitting -- i.e., when the validation loss as a function of epoch is consistently higher than the training loss as a function of epoch (Please see Figure 6 as an example).\n",
+    "* `Linear`: defines a linear layer. Two inputs are considered here:\n",
+    "    * `in_features` (required): the size of the sample input to the layer.\n",
+    "    * `out_features` (required): the size of the sample output from the layer.\n",
+    "\n",
+    "The function `forward` defines the order of operations during a forward pass of the model. During training, the `forward` function is applied to the input data to make predictions. After each round of predictions (epoch), the optimizer is engaged to take the difference between the true labels and the predicted labels and then use that difference to update the model weights. \n",
+    "\n",
+    "The `forward` function uses the layers defined in the constructor, as well as other layers that don't require inputs that depend on the data. These layers are defined in the `torch.nn.functional` submodule, which contains predefined functions for layers that operate directly on the data and don't require an instance of that layer. These `functional` layers are \n",
+    "* `relu`: applies the `ReLU` activation function. It requires one input, the sample from the previous layer.\n",
+    "* `max_pool2d`: the max pooling function is applied to the sample from the previous layer. It requires the input sample and the size of the kernel of the pooling.\n",
+    "* `flatten`: reshapes the sample input into a one-dimensional tensor."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### 3.2.4. Define the object class that represents the model "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class ConvNet(nn.Module):\n",
+    "    def __init__(self):\n",
+    "        super(ConvNet, self).__init__()\n",
+    "        self.conv1 = nn.Conv2d(1, 32, 3, 1)\n",
+    "        self.conv2 = nn.Conv2d(32, 64, 3, 1)\n",
+    "        self.dropout1 = nn.Dropout(0.25)\n",
+    "        self.dropout2 = nn.Dropout(0.5)\n",
+    "        self.fc1 = nn.Linear(9216, 128)\n",
+    "        self.fc2 = nn.Linear(128, 10)\n",
+    "\n",
+    "    def forward(self, x):\n",
+    "        x = self.conv1(x)\n",
+    "        x = F.relu(x)\n",
+    "        x = self.conv2(x)\n",
+    "        x = F.relu(x)\n",
+    "        x = F.max_pool2d(x, 2)\n",
+    "        x = self.dropout1(x)\n",
+    "        x = torch.flatten(x, 1)\n",
+    "        x = self.fc1(x)\n",
+    "        x = F.relu(x)\n",
+    "        x = self.dropout2(x)\n",
+    "        x = self.fc2(x)\n",
+    "        output = x\n",
+    "        return output"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Instantiate a neural network model object."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model = ConvNet()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Define the device. This is important especially when a GPU is available. This is necessary because the model and the data get moved to that device.\n",
+    "\n",
+    "In our case, the device is a CPU because that's what is currently available on the RSP."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "device = torch.device('cuda') if torch.cuda.is_available()\\\n",
+    "    else torch.device('cpu')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Put the model on the device where the computations will be performed.\n",
+    "\n",
+    "When placing the model on the device, it also shows a summary of the network architecture. Examine the shapes of the layers and the number of parameters in each layer. Too few parameters may prevent the model from being flexible enough to model the data. Too many parameters could lead to overfitting of the model (e.g., 'memorizing' the training data) and an unnecessarily high computational cost. Typically, models range from thousands to millions of parameters. There is an interplay between model size (number of parameters), the amount of training data, and the complexity of the images in the training data."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(\"Model Summary:\\n\")\n",
+    "model.to(device)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### 3.2.5. Glossary: hyperparameters for the training schedule"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "* `learning rate`: A multiplicative factor defining the amount that the model weights will change in response to the size of the error (loss) in the model prediction for that epoch. The lower the learning rate, the smaller the change to the weights, and usually the longer it will take to train the model. However, if the learning rate is too high, the weights can change too quickly: then, the loss can fluctuate significantly and not decrease quickly.\n",
+    "* `momentum`: A multiplicative factor on the aggregate of previous gradients. This aggregate term is combined with the weight gradient term to define the total change in the value of the weights. The smaller the momentum, the lesser the influence of the aggregated gradients, and usually the longer it will take train the model.\n",
+    "* `optimizer`: The method/algorithm used to update the network weights. Stochastic Gradient Descent (SGD) is the most commonly used method.\n",
+    "* `epoch`: One loop of training the model. Each loop includes the entire data set (all the batches) once, and it includes at least one round of weight updates.\n",
+    "* `n_epochs`: The number of epochs to train the network."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### 3.2.6. Assign hyperparameters for the training schedule"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "learning_rate = 0.01\n",
+    "momentum = 0.9\n",
+    "optimizer = optim.SGD(model.parameters(), lr=learning_rate, momentum=momentum)\n",
+    "n_epochs = 50"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 3.3. Train the model"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Set the model into a training context. This ensures that layers like \"batchnorm\" and \"dropout\" will be activated. In contrast, when the model is set to an evaluation context (later in this tutorial), those layers will be deactivated."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%capture\n",
+    "model.train()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Use a loop over epochs to incrementally optimize the network weight parameters. \n",
+    "\n",
+    "Use lists to track the loss values on the training data, the loss values on the testing data, and the accuracy values on the testing data. Define the \"history\" dictionary to hold those lists. We will visualize these later to study the fitting efficacy and generalization capacity of the network.\n",
+    "\n",
+    "For this tutorial, 50 epochs on the medium-memory Rubin server required ~9 min of wall time and ~15min of CPU time."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "zB1OY3o8VWF_",
+    "outputId": "7bdd7e85-cef2-47af-f16b-5f8bbd66f67f"
+   },
+   "outputs": [],
+   "source": [
+    "%%time\n",
+    "time_start = time.time()\n",
+    "\n",
+    "loss_train_list = []\n",
+    "loss_test_list = []\n",
+    "accuracy_test_list = []\n",
+    "\n",
+    "for epoch in np.arange(n_epochs):\n",
+    "\n",
+    "    loss_train = 0\n",
+    "    for inputs, labels in trainloader:\n",
+    "        inputs = inputs.to(device)\n",
+    "        labels = labels.to(device)\n",
+    "        y_pred = model(inputs)\n",
+    "        loss = loss_fn(y_pred, labels)\n",
+    "        optimizer.zero_grad()\n",
+    "        loss.backward()\n",
+    "        optimizer.step()\n",
+    "        loss_train += loss.item()\n",
+    "\n",
+    "    loss_train /= batch_size\n",
+    "\n",
+    "    accuracy_test = 0\n",
+    "    loss_test = 0\n",
+    "    count_test = 0\n",
+    "    for inputs, labels in testloader:\n",
+    "        inputs = inputs.to(device)\n",
+    "        labels = labels.to(device)\n",
+    "        y_pred = model(inputs)\n",
+    "        loss = loss_fn(y_pred, labels)\n",
+    "        accuracy_test += (torch.argmax(y_pred, 1) == labels).float().sum()\n",
+    "        loss_test += loss.item()\n",
+    "        count_test += len(labels)\n",
+    "\n",
+    "    accuracy_test /= count_test\n",
+    "    loss_test /= batch_size\n",
+    "\n",
+    "    loss_train_list.append(loss_train)\n",
+    "    loss_test_list.append(loss_test)\n",
+    "    accuracy_test_list.append(accuracy_test)\n",
+    "\n",
+    "    # output = f\"Epoch ({epoch:3d}):   accuracy ({accuracy_test*100:.2f} %),\\\n",
+    "    output1 = f\"Epoch ({epoch:2d}):   accuracy ({accuracy_test*50:.2f} %),  \"\n",
+    "    output2 = f\"train loss ({loss_train:.4f}),  valid loss ({loss_test:.4f})\"\n",
+    "    output = output1 + output2\n",
+    "    print(output)\n",
+    "\n",
+    "time_end = time.time()\n",
+    "\n",
+    "time_difference = time_end - time_start\n",
+    "\n",
+    "history = {\"loss\": loss_train_list,\n",
+    "           \"val_loss\": loss_test_list,\n",
+    "           \"accuracy_test\": accuracy_test_list}\n",
+    "\n",
+    "print(f\"Total training time: {time_difference/60.:2.4f} min\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Save model to file: \"pt\" is the common suffix used for pytorch model files. This saves the architecture and weights of the model."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "file_prefix = path_dict['file_model_prefix'] + \"_\" + path_dict['run_label']\n",
+    "file_name_final = createFileName(file_prefix=file_prefix,\n",
+    "                                 file_location=path_dict['dir_data_model'],\n",
+    "                                 file_suffix=path_dict['file_model_suffix'],\n",
+    "                                 useuid=True,\n",
+    "                                 verbose=True)\n",
+    "\n",
+    "torch.save(model.state_dict(), file_name_final)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Load the model from a \"pt\" file."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%capture\n",
+    "model.load_state_dict(torch.load(file_name_final, weights_only=False))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Set the model to evaluation mode so that the \"batchnorm\" and \"dropout\" layers are deactivated. This is necessary for consistent inference."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%capture\n",
+    "model.eval()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. Diagnosing the Results of Model Training"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In this section, you will encounter the following items:\n",
+    "\n",
+    "1. a glossary for diagnostics for model evaluation;\n",
+    "2. how to make predictions with the trained model;\n",
+    "3. basic bulk diagnostic: loss history;\n",
+    "4. basic bulk diagnostic: confusion matrix (CM);\n",
+    "5. basic bulk diagnostic: receiver operator characteristic (ROCH) curve;\n",
+    "6. investigating predictions of individual images."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 4.1. Glossary: diagnostics and model evaluation"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Use the following diagnostics to assess the status of the network optimization and efficacy. The [scikit-learn page on metrics and scoring](https://scikit-learn.org/stable/modules/model_evaluation.html) provides a good in-depth reference for these terms.\n",
+    "\n",
+    "Model Predictions:\n",
+    " * `Classification threshold`: The user-chosen value $[0,1]$ that sets the threshold for a positive classification. \n",
+    " * `Probability score`: The output from the classifier neural network. One typically uses the `softmax` activation function in the last layer of the NN to provide an output in the range $[0,1]$.\n",
+    " * `Classification score`: The predicted class label is the class that received the highest probability score.\n",
+    "\n",
+    "Metrics:\n",
+    " * `Loss`: A function of the difference between the true labels and predicted labels.\n",
+    " * `Accuracy`: A rough indicator of model training progress/convergence for balanced datasets. For model performance, use only in combination with other metrics. Avoid this metric when you have unbalanced training datasets. Consider using another metric.\n",
+    " * `True Positive Rate (TPR; \"Recall\")`: Use when false negatives are more expensive than false positives.\n",
+    " * `False Positive Rate (FPR)`: Use when false positives are more expensive than false negatives.\n",
+    " * `Precision`: Use when positive predictions need to be accurate.\n",
+    "\n",
+    "The `Generalization Error` (GE) is the difference in loss when the model is applied to training data versus when applied to validation and test data.\n",
+    "\n",
+    "The `Confusion Matrix` (CM) is a visual representation of the classification accuracy. Each row is the set of predictions for each true value (with one true value per column). Values along the diagonal indicate true positives (correct predictions). Values below the diagonal indicate false positives. Values above the diagonal indicate false negatives. The optimal scenario is one in which the off-diagonal values are all zero.\n",
+    "\n",
+    "The `Receiver Operator Characteristic (ROC) Curve` presents a comparison between the true positive rate (y-axis) and the false positive rate (x-axis) --- for a given false positive rate, the number of true positives that exist. Each point on the curve is for a distinct choice of the Classification threshold for the probability score $[0,1]$: the choice of classification threshold determines which objects are considered correctly classified. The optimal scenario is where the ROC curve is constant at a true positive rate $=1$. If the curve is along the diagonal (lower left to upper right), it indicates that the model performance is equivalent to 50-50 guessing."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 4.2. Predict classifications with the trained model"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Predict classification probabilities on the training, validation, and test sets. Produce both the probabilities of each digit and the top choice for each prediction."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "y_prob_tes, y_choice_tes, y_true_tes, x_tes = predict(testloader, model,\n",
+    "                                                      \"test\")\n",
+    "y_prob_val, y_choice_val, y_true_val, x_val = predict(validloader, model,\n",
+    "                                                      \"validation\")\n",
+    "y_prob_tra, y_choice_tra, y_true_tra, x_tra = predict(trainloader, model,\n",
+    "                                                      \"training\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Print the shapes and verify that the shape of `y_prob_tes` matches the length of the input data `x_tes` and the number of classes. (as in Section 2.4)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(f\"The input data has the shape {np.shape(x_tes)}: there the {subset_size}\\\n",
+    " images each image has 28 pixels on a side.\")\n",
+    "print(f\"The predicted probability score array has the shape\\\n",
+    " {np.shape(y_prob_tes)}: there are {subset_size} predictions,\\\n",
+    " with 10 probability scores predicted for each input image.\")\n",
+    "print(f\"The predicted classes array has has the shape {np.shape(y_choice_tes)}:\\\n",
+    " there is one top choice (highest probability score) for each prediction.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Use the `plotPredictionHistogram` function to plot histograms of prediction distributions by class."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "file_prefix = path_dict['file_figure_prefix'] + \"_\"\\\n",
+    "    + \"Histograms_top_choice\"\\\n",
+    "    + \"_\" + path_dict['run_label']\n",
+    "\n",
+    "plotPredictionHistogram(y_choice_tra,\n",
+    "                        y_prediction_b=y_choice_val,\n",
+    "                        y_prediction_c=y_choice_tes,\n",
+    "                        label_a=\"Training Set\",\n",
+    "                        label_b=\"Validation Set\",\n",
+    "                        label_c=\"Testing Set\",\n",
+    "                        figsize=(12, 5),\n",
+    "                        alpha=0.5,\n",
+    "                        xlabel_plot=\"Predicted class label\",\n",
+    "                        file_prefix=file_prefix,\n",
+    "                        file_location=path_dict['dir_data_figures'],\n",
+    "                        file_suffix=path_dict['file_figure_suffix'])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "> Figure 4: Histograms of the number of images for which the top-choice class was each number 0 through 9. Each histogram is for a different data set used during model training --- training data, validation data, and test data. Note that these are overlapping histograms, not stacked. Please compare to Figure 3, which shows the distributions of true class labels for each data set. Consider which classes are represented differently between the true labels and the predicted labels."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "file_prefix = path_dict['file_figure_prefix'] + \"_\"\\\n",
+    "    + \"Histograms_class_probabilities\"\\\n",
+    "    + \"_\" + path_dict['run_label']\n",
+    "\n",
+    "plotPredictionHistogram(y_prob_tra,\n",
+    "                        y_prediction_b=y_prob_val,\n",
+    "                        y_prediction_c=y_prob_tes,\n",
+    "                        title_a='Training Set',\n",
+    "                        title_b='Validation Set',\n",
+    "                        title_c='Testing Set',\n",
+    "                        figsize=(15, 4),\n",
+    "                        file_prefix=file_prefix,\n",
+    "                        file_location=path_dict['dir_data_figures'],\n",
+    "                        file_suffix=path_dict['file_figure_suffix'])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "> Figure 5: Histograms of the number of images (y-axis) that had a probability (x-axis) of being each class 0 through 9 (light to dark shades)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In both of Figure 3 and 4, the histograms show very similar shapes across the classification categories.\n",
+    "This is a good sign because it indicates the model is not heavily biased toward a particular class."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 4.3. Loss History: History of Loss and Accuracy during Training"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The primary task in optimizing a network is to minimize the Generalization Error. Plot the loss history for the validation and training sets. We reserve the test set for a 'blind' analysis."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "file_prefix = path_dict['file_figure_prefix'] + \"_\"\\\n",
+    "                                              + \"LossHistory\"\\\n",
+    "                                              + \"_\"\\\n",
+    "                                              + path_dict['run_label']\n",
+    "\n",
+    "plotLossHistory(history,\n",
+    "                file_prefix=file_prefix,\n",
+    "                file_location=path_dict['dir_data_figures'],\n",
+    "                file_suffix=path_dict['file_figure_suffix'])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "> Figure 6: The loss histories for the training and validation data sets and the loss residual history between the training and the validation set. Top panel: the loss history as a function of epoch for the training and validation sets decreases with time, as it should as the model fit improves. There is slight difference between the validation and the training. Bottom panel: the loss residual (validation loss minus training loss) shows a minimum near epoch 34, indicating the model-fitting underwent a divergence between the classifications, but that this was rectified in later epochs. For epochs 10 to 44, the difference between validation and training data indicates that the validation data may not have been represeentative of the training data."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Another pattern you may encounter is when the validation loss is consistently higher than the training loss. This typically indicates overfitting, which is when the model is complex enough to fit (sometimes, the term 'memorize' is used) all the details of the training data and not generalize enough to also fit the validation data."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 4.4. Confusion Matrix: Bias in Trained Model?"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Compute and plot the confusion matrices for the training, validation, and test samples (left, right, middle)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "classes = ('0', '1', '2', '3', '4', '5', '6', '7', '8', '9')\n",
+    "figsize = (15, 3)\n",
+    "linewidths = 0.01\n",
+    "linecolor = 'white'\n",
+    "ylabel = \"Predicted Label\"\n",
+    "xlabel = \"True Label\"\n",
+    "\n",
+    "cm_tra = confusion_matrix(y_true_tra, y_choice_tra)\n",
+    "cm_val = confusion_matrix(y_true_val, y_choice_val)\n",
+    "cm_tes = confusion_matrix(y_true_tes, y_choice_tes)\n",
+    "\n",
+    "df_cm_tra = pd.DataFrame(cm_tra / np.sum(cm_tra, axis=1)[:, None],\n",
+    "                         index=[i for i in classes],\n",
+    "                         columns=[i for i in classes])\n",
+    "df_cm_val = pd.DataFrame(cm_val / np.sum(cm_val, axis=1)[:, None],\n",
+    "                         index=[i for i in classes],\n",
+    "                         columns=[i for i in classes])\n",
+    "df_cm_tes = pd.DataFrame(cm_tes / np.sum(cm_tes, axis=1)[:, None],\n",
+    "                         index=[i for i in classes],\n",
+    "                         columns=[i for i in classes])\n",
+    "\n",
+    "fig, (axa, axb, axc) = plt.subplots(1, 3, figsize=figsize)\n",
+    "fig.subplots_adjust(wspace=0.5)\n",
+    "\n",
+    "ax1 = sns.heatmap(df_cm_tra, annot=False, linewidths=linewidths,\n",
+    "                  linecolor=linecolor, square=True, ax=axa)\n",
+    "_ = ax1.set(xlabel=xlabel, ylabel=ylabel, title=\"Training Data\")\n",
+    "\n",
+    "ax2 = sns.heatmap(df_cm_val, annot=False, linewidths=linewidths,\n",
+    "                  linecolor=linecolor, square=True, ax=axb)\n",
+    "_ = ax2.set(xlabel=xlabel, ylabel=ylabel, title=\"Validation Data\")\n",
+    "\n",
+    "ax3 = sns.heatmap(df_cm_tes, annot=False, linewidths=linewidths,\n",
+    "                  linecolor=linecolor, square=True, ax=axc)\n",
+    "_ = ax3.set(xlabel=xlabel, ylabel=ylabel, title=\"Test Data\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "> Figure 7: Confusion matrices for the training, validation, and test data sets (left to right). Each cell in the matrix shows the fraction (see the color bars) of the total objects with that true label that have been predicted to be a given label. The diagonal represents images that were correctly classified. All off-diagonal cells represent false positives (lower left) or false negatives (upper right). Consider some examples. First, the class \"0\" is almost always predicted to be \"0\" with a lighter color in the top-most, left-most cell; all the other cells in the column are completely dark. Second, consider the cell that represents a prediction \"4\", when the true label is \"9\": that cell is not completely dark. A \"4\" has a similar morphology or shape as a \"9.\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 4.5. Receiver Operator Characteristic (ROC) Curve: Trade-offs between Completeness and Purity"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The Receiver Operator Characteristic (ROC) Curve is a plot of the True Positive Rate (TPR; y axis) versus the False Positive Rate (FPR; x axis).\n",
+    "\n",
+    "For a given classification threshold on the probability (canonically, 0.5), the balance of true positives and false positives will change."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "file_prefix = path_dict['file_figure_prefix'] + \"_\"\\\n",
+    "                                              + \"ROCCurve\"\\\n",
+    "                                              + \"_\"\\\n",
+    "                                              + path_dict['run_label']\n",
+    "\n",
+    "plotROCMulticlassOnevsrest(y_tra, y_tes, y_prob_tes,\n",
+    "                              save_file=True,\n",
+    "                              file_prefix=file_prefix,\n",
+    "                              file_location=path_dict['dir_data_figures'],\n",
+    "                              file_suffix=path_dict['file_figure_suffix'])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "> Figure 8: ROC curve for classification of one digit (class) against the remaining nine digits (classes). All of the curves show a very high AUC, which means near-perfect classification. The black dashed line shows an ROC curve representing a 50-50 guess. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "vvAqrZwjVYBt"
+   },
+   "source": [
+    "### 4.5. Investigating predictions in detail"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### 4.5.1. Glossary: classification metrics"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Consider the example of true class label being \"2\". Then, we define the following metrics.\n",
+    "\n",
+    "* `True Positive (TP)`: correctly classified input digit image --- e.g., a \"2\" classified as \"2\".\n",
+    "* `False Positive (FP)`: another digit classified as \"2\".\n",
+    "* `True Negative (TN)`: another digit classified as another digit.\n",
+    "* `False Negative (FN)`: a \"2\" classified as something other than \"2\"."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### 4.5.2. Explore the classification of the training data for an example class value"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Investigate the case in which the true digit label is \"2\"."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class_value = 2"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Find all objects that have that class value. Obtain indices for the TP's, FP's, TN's, and FN's. Create subsets of the data according to those indices."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ind_class_tp_tra = np.where((y_true_tra == class_value)\n",
+    "                            & (y_choice_tra == class_value))[0]\n",
+    "\n",
+    "ind_class_fp_tra = np.where((y_true_tra != class_value)\n",
+    "                            & (y_choice_tra == class_value))[0]\n",
+    "\n",
+    "ind_class_tn_tra = np.where((y_true_tra != class_value)\n",
+    "                            & (y_choice_tra != class_value))[0]\n",
+    "\n",
+    "ind_class_fn_tra = np.where((y_true_tra == class_value)\n",
+    "                            & (y_choice_tra != class_value))[0]\n",
+    "\n",
+    "x_tra_tp = x_tra[ind_class_tp_tra]\n",
+    "y_true_tra_tp = y_true_tra[ind_class_tp_tra]\n",
+    "y_choice_tra_tp = y_choice_tra[ind_class_tp_tra]\n",
+    "\n",
+    "x_tra_fp = x_tra[ind_class_fp_tra]\n",
+    "y_true_tra_fp = y_true_tra[ind_class_fp_tra]\n",
+    "y_choice_tra_fp = y_choice_tra[ind_class_fp_tra]\n",
+    "\n",
+    "x_tra_tn = x_tra[ind_class_tn_tra]\n",
+    "y_true_tra_tn = y_true_tra[ind_class_tn_tra]\n",
+    "y_choice_tra_tn = y_choice_tra[ind_class_tn_tra]\n",
+    "\n",
+    "x_tra_fn = x_tra[ind_class_fn_tra]\n",
+    "y_true_tra_fn = y_true_tra[ind_class_fn_tra]\n",
+    "y_choice_tra_fn = y_choice_tra[ind_class_fn_tra]\n",
+    "\n",
+    "n_tp = len(ind_class_tp_tra)\n",
+    "n_fp = len(ind_class_fp_tra)\n",
+    "n_tn = len(ind_class_tn_tra)\n",
+    "n_fn = len(ind_class_fn_tra)\n",
+    "\n",
+    "print(f\"TP count: {n_tp:4d}\")\n",
+    "print(f\"FP count: {n_fp:4d}\")\n",
+    "print(f\"TN count: {n_tn:4d}\")\n",
+    "print(f\"FN count: {n_fn:4d}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if n_tp > 0:\n",
+    "    file_prefix = path_dict['file_figure_prefix'] + \"_\"\\\n",
+    "        + \"ExampleImages_TruePostives_on_class_\"\\\n",
+    "        + str(class_value) + \"_\" + path_dict['run_label']\n",
+    "    plotArrayImageConfusion(x_tra_tp,\n",
+    "                            y_true_tra_tp,\n",
+    "                            y_choice_tra_tp,\n",
+    "                            title_main=\"True Positives\",\n",
+    "                            num=10,\n",
+    "                            file_prefix=file_prefix,\n",
+    "                            file_location=path_dict['dir_data_figures'],\n",
+    "                            file_suffix=path_dict['file_figure_suffix'])\n",
+    "\n",
+    "if n_fp > 0:\n",
+    "    file_prefix = path_dict['file_figure_prefix'] + \"_\"\\\n",
+    "        + \"ExampleImages_FalsePostives_on_class_\"\\\n",
+    "        + str(class_value) + \"_\" + path_dict['run_label']\n",
+    "    plotArrayImageConfusion(x_tra_fp,\n",
+    "                            y_true_tra_fp,\n",
+    "                            y_choice_tra_fp,\n",
+    "                            title_main=\"False Positives\",\n",
+    "                            num=10,\n",
+    "                            file_prefix=file_prefix,\n",
+    "                            file_location=path_dict['dir_data_figures'],\n",
+    "                            file_suffix=path_dict['file_figure_suffix'])\n",
+    "\n",
+    "if n_tn > 0:\n",
+    "    file_prefix = path_dict['file_figure_prefix'] + \"_\"\\\n",
+    "        + \"ExampleImages_TrueNegatives_on_class_\"\\\n",
+    "        + str(class_value) + \"_\" + path_dict['run_label']\n",
+    "    plotArrayImageConfusion(x_tra_tn,\n",
+    "                            y_true_tra_tn,\n",
+    "                            y_choice_tra_tn,\n",
+    "                            title_main=\"True Negatives\",\n",
+    "                            num=10,\n",
+    "                            file_prefix=file_prefix,\n",
+    "                            file_location=path_dict['dir_data_figures'],\n",
+    "                            file_suffix=path_dict['file_figure_suffix'])\n",
+    "\n",
+    "if n_fn > 0:\n",
+    "    file_prefix = path_dict['file_figure_prefix'] + \"_\"\\\n",
+    "        + \"ExampleImages_FalseNegatives_on_class_\"\\\n",
+    "        + str(class_value) + \"_\" + path_dict['run_label']\n",
+    "    plotArrayImageConfusion(x_tra_fn,\n",
+    "                            y_true_tra_fn,\n",
+    "                            y_choice_tra_fn,\n",
+    "                            title_main=\"False Negatives\",\n",
+    "                            num=10,\n",
+    "                            file_prefix=file_prefix,\n",
+    "                            file_location=path_dict['dir_data_figures'],\n",
+    "                            file_suffix=path_dict['file_figure_suffix'])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "> Figure 9: Four panels of 10 images each, representing true positives (top), false positives (second), true negatives (third), and false negatives (bottom), for classification category 2.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Plot histograms of images pixels of true positives, false positives, true negatives, and false negatives."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if n_tp > 0:\n",
+    "    file_prefix = path_dict['file_figure_prefix']\\\n",
+    "        + \"_\" + \"ExampleImages_TruePostives_on_class_\"\\\n",
+    "        + str(class_value) + \"_\" + path_dict['run_label']\n",
+    "    plotArrayHistogramConfusion(x_tra_tp,\n",
+    "                                y_true_tra_tp,\n",
+    "                                y_choice_tra_tp,\n",
+    "                                title_main=\"True Positives\",\n",
+    "                                num=10,\n",
+    "                                file_prefix=file_prefix,\n",
+    "                                file_location=path_dict['dir_data_figures'],\n",
+    "                                file_suffix=path_dict['file_figure_suffix'])\n",
+    "\n",
+    "if n_fp > 0:\n",
+    "    file_prefix = path_dict['file_figure_prefix']\\\n",
+    "        + \"_\" + \"ExampleImages_FalsePostives_on_class_\"\\\n",
+    "        + str(class_value) + \"_\" + path_dict['run_label']\n",
+    "    plotArrayHistogramConfusion(x_tra_fp,\n",
+    "                                y_true_tra_fp,\n",
+    "                                y_choice_tra_fp,\n",
+    "                                title_main=\"False Positives\",\n",
+    "                                num=10,\n",
+    "                                file_prefix=file_prefix,\n",
+    "                                file_location=path_dict['dir_data_figures'],\n",
+    "                                file_suffix=path_dict['file_figure_suffix'])\n",
+    "\n",
+    "if n_tn > 0:\n",
+    "    file_prefix = path_dict['file_figure_prefix']\\\n",
+    "        + \"_\" + \"ExampleImages_TrueNegatives_on_class_\"\\\n",
+    "        + str(class_value) + \"_\" + path_dict['run_label']\n",
+    "    plotArrayHistogramConfusion(x_tra_tn,\n",
+    "                                y_true_tra_tn,\n",
+    "                                y_choice_tra_tn,\n",
+    "                                title_main=\"True Negatives\",\n",
+    "                                num=10,\n",
+    "                                file_prefix=file_prefix,\n",
+    "                                file_location=path_dict['dir_data_figures'],\n",
+    "                                file_suffix=path_dict['file_figure_suffix'])\n",
+    "\n",
+    "if n_fn > 0:\n",
+    "    file_prefix = path_dict['file_figure_prefix']\\\n",
+    "        + \"_\" + \"ExampleImages_FalseNegatives_on_class_\"\\\n",
+    "        + str(class_value) + \"_\" + path_dict['run_label']\n",
+    "    plotArrayHistogramConfusion(x_tra_fn,\n",
+    "                                y_true_tra_fn,\n",
+    "                                y_choice_tra_fn,\n",
+    "                                title_main=\"False Negatives\",\n",
+    "                                num=10,\n",
+    "                                file_prefix=file_prefix,\n",
+    "                                file_location=path_dict['dir_data_figures'],\n",
+    "                                file_suffix=path_dict['file_figure_suffix'])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "> Figure 10: Histograms of the pixel flux values for the images shown in Figure 8. Here, it is difficult to infer reasons for network classification errors like false positives and false negatives. If it is expected that a particular would have a particular distribution of pixel brightnesses, but the histogram for the predicted digit has a different distribution, that may help you identify a pattern. This may be a more useful diagnostic for physics-related data, like galaxy light profiles."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### 4.5.3. Investigate morphological features of images with feature maps"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The last diagnostic of this tutorial is the `feature map`, which shows how that one layer affects or processes the input image after the weights have been set during the model training. The morphological elements in the feature maps are the image regions that are highlighed by the earliest layers of convolution and activation functions.\n",
+    "\n",
+    "The feature map is obtained by passing an input image through one layer of the trained neural network model. More specifically, we first choose an input datum (image) by setting the array index of interest. Then, we make the image a `tensor` with the appropriate number of dimensions using `unsqueeze`. Then, we transfer it to the `device`. Next, we choose the `conv1` layer defined the section above where we defined the `model`. Finally, we use the number of convolutional kernels (32) that exist in the `conv1` layer of the model. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "index_input_image = 1\n",
+    "number_conv_kernels = 32\n",
+    "\n",
+    "input_image = dataset.data[index_input_image].type(torch.float32)\n",
+    "input_image = input_image.clone().detach()\n",
+    "input_image = input_image.unsqueeze(0)\n",
+    "input_image = input_image.to(device)\n",
+    "\n",
+    "with torch.no_grad():\n",
+    "    feature_maps = model.conv1(input_image).cpu()\n",
+    "\n",
+    "fig, ax = plt.subplots(4, 8, sharex=True, sharey=True, figsize=(16, 8))\n",
+    "\n",
+    "for i in range(0, number_conv_kernels):\n",
+    "    row, col = i//8, i%8\n",
+    "    ax[row][col].imshow(feature_maps[i])\n",
+    "\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "> Figure 11: `Feature maps` of one input from the `conv1` layer of the `model`. The units on the x- and y-axes are the pixel indices. There are 32 images because there are 32 convolutional kernels in the `conv1` layer.\n",
+    ">\n",
+    "> The feature maps derived from the trained model show which morphological features --- e.g., lines and edges --- are favored by the model. When the model is accurate, these features and feature maps will accurately reflect the input image. In this example, the handwritten digit is \"0,\" and the feature maps all appear as \"0's\". Some maps have more clearly defined edges and \"0\"-like features than others, because each convolutional kernel has a distinct weight parameter associated with it. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 5. Exercises for the Learner"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Each time you train a new model, re-run all the diagnostic plots.\n",
+    "\n",
+    "1. How do the loss and accuracy histories change when batch size is small or large? Why?\n",
+    "2. Does the NN take more or less time (more or fewer epochs) to converge if the input image data are normalized or not normalized? Why?\n",
+    "3. How does the size of the training set affect the model's accuracy and loss -- keeping the number of epochs the same? Why?\n",
+    "3. How does the random seed for the weight initialization affect the model's accuracy and loss -- keeping the number of epochs the same?\n",
+    "5. Increase and then decrease the number of weights in the NN by an order of magnitude. Train the NN for each of those models and record the times. How does the number of weights in the neural network affect the training time and model loss and accuracy?\n",
+    "6. Increase and then decrease the number of layers in the NN. Train the NN for each of those models and record the times. How does the number of weights in the neural network affect the training time and model loss and accuracy?\n",
+    "7. Make new ROC curves using the validation data and the training data. Are the results consistent with those from the test data?\n",
+    "8. Change the pytorch random seed, and re-run the training and model evaluation. Have the results changed?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "accelerator": "GPU",
+  "colab": {
+   "gpuType": "T4",
+   "machine_shape": "hm",
+   "provenance": []
+  },
+  "kernelspec": {
+   "display_name": "LSST",
+   "language": "python",
+   "name": "lsst"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/DP0.3/01_Introduccion_a_DP03_ES.ipynb
+++ b/DP0.3/01_Introduccion_a_DP03_ES.ipynb
@@ -8,8 +8,8 @@
     "<img align=\"left\" src = https://project.lsst.org/sites/default/files/Rubin-O-Logo_0.png width=250 style=\"padding: 10px\"> \n",
     "<br><b>Introducción a DP0.3</b> <br>\n",
     "Autoría: Bob Abel, Douglas Tucker y Melissa Graham<br>\n",
-    "Última verificación de ejecución: 2025-03-06 <br>\n",
-    "Versión de las Pipelines Científicas de LSST: Weekly 2025_09 <br>\n",
+    "Última verificación de ejecución: 2025-04-30 <br>\n",
+    "Versión de las Pipelines Científicas de LSST: Weekly 2025_17 <br>\n",
     "Tamaño del contenedor (Container size): medium <br>\n",
     "Nivel de aprendizaje: principiante<br>"
    ]
@@ -1224,7 +1224,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.9"
+   "version": "3.12.10"
   }
  },
  "nbformat": 4,

--- a/DP0.3/01_Introduction_to_DP03.ipynb
+++ b/DP0.3/01_Introduction_to_DP03.ipynb
@@ -8,8 +8,8 @@
     "# Introduction to the DP0.3\n",
     "<img align=\"left\" src = https://project.lsst.org/sites/default/files/Rubin-O-Logo_0.png width=250 style=\"padding: 10px\"> \n",
     "Contact author(s): Bob Abel, Douglas Tucker, and Melissa Graham<br>\n",
-    "Last verified to run: 2025-03-06 <br>\n",
-    "LSST Science Piplines version: Weekly 2025_09 <br>\n",
+    "Last verified to run: 2025-04-30 <br>\n",
+    "LSST Science Pipelines version: Weekly 2025_17 <br>\n",
     "Container size: medium <br>\n",
     "Targeted learning level: beginner <br>"
    ]
@@ -1413,7 +1413,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.9"
+   "version": "3.12.10"
   }
  },
  "nbformat": 4,

--- a/DP0.3/03_Trans-Neptunian_Objects.ipynb
+++ b/DP0.3/03_Trans-Neptunian_Objects.ipynb
@@ -10,8 +10,8 @@
     "# Trans-Neptunian Objects (TNOs)\n",
     "<img align=\"left\" src = https://project.lsst.org/sites/default/files/Rubin-O-Logo_0.png width=250 style=\"padding: 10px\"> \n",
     "Contact author(s): Andrés A. Plazas Malagón<br>\n",
-    "Last verified to run: 2025-03-06 <br>\n",
-    "LSST Science Pipelines version: Weekly 2025_09 <br>\n",
+    "Last verified to run: 2025-04-30 <br>\n",
+    "LSST Science Pipelines version: Weekly 2025_17 <br>\n",
     "Container Size: medium <br>\n",
     "Targeted learning level: intermediate<br>"
    ]
@@ -1892,7 +1892,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.9"
+   "version": "3.12.10"
   }
  },
  "nbformat": 4,

--- a/DP0.3/04a_Introduction_to_Phase_Curves.ipynb
+++ b/DP0.3/04a_Introduction_to_Phase_Curves.ipynb
@@ -9,8 +9,8 @@
     "<img align=\"left\" src = https://project.lsst.org/sites/default/files/Rubin-O-Logo_0.png width=250 style=\"padding: 10px\"> \n",
     "<br>\n",
     "Contact authors: Christina Williams and Yumi Choi<br>\n",
-    "Last verified to run: 2025-03-06 <br>\n",
-    "LSST Science Piplines version: Weekly 2025_09 <br>\n",
+    "Last verified to run: 2025-04-30 <br>\n",
+    "LSST Science Pipelines version: Weekly 2025_17 <br>\n",
     "Container Size: medium <br>\n",
     "Targeted learning level: intermediate <br>"
    ]
@@ -1163,7 +1163,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.9"
+   "version": "3.12.10"
   },
   "toc-autonumbering": false
  },

--- a/DP0.3/04b_Advanced_Phase_Curve_Modeling.ipynb
+++ b/DP0.3/04b_Advanced_Phase_Curve_Modeling.ipynb
@@ -8,8 +8,8 @@
     "# Phase Curve of Solar System Objects\n",
     "<img align=\"left\" src = https://project.lsst.org/sites/default/files/Rubin-O-Logo_0.png width=250 style=\"padding: 10px\"> \n",
     "Contact authors: Yumi Choi and Christina Williams<br>\n",
-    "Last verified to run: 2025-03-06 <br>\n",
-    "LSST Science Piplines version: Weekly 2025_09 <br>\n",
+    "Last verified to run: 2025-04-30 <br>\n",
+    "LSST Science Pipelines version: Weekly 2025_17 <br>\n",
     "Container Size: medium <br>\n",
     "Targeted learning level: advanced <br>"
    ]
@@ -1057,7 +1057,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.9"
+   "version": "3.12.10"
   },
   "toc-autonumbering": false
  },

--- a/DP0.3/05_Near-Earth_Objects.ipynb
+++ b/DP0.3/05_Near-Earth_Objects.ipynb
@@ -8,8 +8,8 @@
     "# Orbital Properties of Near-Earth Objects (NEOs)</b>\n",
     "<img align=\"left\" src = https://project.lsst.org/sites/default/files/Rubin-O-Logo_0.png width=250 style=\"padding: 10px\"> \n",
     "Contact author(s): Sarah Greenstreet <br>\n",
-    "Last verified to run: 2025-03-06 <br>\n",
-    "LSST Science Pipelines version: Weekly 2025_09 <br>\n",
+    "Last verified to run: 2025-04-30 <br>\n",
+    "LSST Science Pipelines version: Weekly 2025_17 <br>\n",
     "Container Size: medium <br>\n",
     "Targeted learning level: beginner <br>"
    ]
@@ -1631,7 +1631,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.9"
+   "version": "3.12.10"
   },
   "toc-autonumbering": false
  },

--- a/DP0.3/06_User_Uploaded_Tables.ipynb
+++ b/DP0.3/06_User_Uploaded_Tables.ipynb
@@ -9,8 +9,8 @@
     "<img align=\"left\" src = https://project.lsst.org/sites/default/files/Rubin-O-Logo_0.png width=250 style=\"padding: 10px\"> \n",
     "<br>\n",
     "Contact authors: Yumi Choi <br>\n",
-    "Last verified to run: 2025-03-06 <br>\n",
-    "LSST Science Piplines version: Weekly 2025_09 <br>\n",
+    "Last verified to run: 2025-04-30 <br>\n",
+    "LSST Science Pipelines version: Weekly 2025_17 <br>\n",
     "Container Size: small <br>\n",
     "Targeted learning level: Beginner <br>"
    ]
@@ -1455,7 +1455,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.9"
+   "version": "3.12.10"
   },
   "toc-autonumbering": false
  },

--- a/DP0.3/07_Interactive_Catalog_Visualization.ipynb
+++ b/DP0.3/07_Interactive_Catalog_Visualization.ipynb
@@ -10,8 +10,8 @@
     "# Interactive Solar System Catalog Visualization with Holoviews, Bokeh, and Datashader\n",
     "<img align=\"left\" src = https://project.lsst.org/sites/default/files/Rubin-O-Logo_0.png width=250 style=\"padding: 10px\" alt=\"Rubin Observatory logo, a graphical representation of turning stars into data.\">\n",
     "Contact author(s): Sarah Greenstreet <br>\n",
-    "Last verified to run: 2025-03-06 <br>\n",
-    "LSST Science Pipelines version: Weekly 2025_09 <br>\n",
+    "Last verified to run: 2025-04-30 <br>\n",
+    "LSST Science Pipelines version: Weekly 2025_17 <br>\n",
     "Container Size: large <br>\n",
     "Targeted learning level: intermediate <br>"
    ]
@@ -1892,7 +1892,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.9"
+   "version": "3.12.10"
   },
   "toc-autonumbering": false
  },

--- a/mobu.yaml
+++ b/mobu.yaml
@@ -1,2 +1,3 @@
 exclude_dirs:
   - "DP0.2/11_User_Packages"
+  - "DP0.2/19a_Introduction_to_AI"


### PR DESCRIPTION
Ran and checked tutorial notebooks on both `w_2025_09` and `w_2025_17` and compared results using a combination of nbdiff and manual inspection.  

All looks good for the bump to `w_2025_17`.

The headers of each notebook were updated to reflect the "Last verified to run" date (2025-04-30) and the LSST Science Pipelines version (Weekly 2025_17).

In addition, a minor bug in DP0.2 notebook `13a_Image_Cutout_Scidemo.ipynb`, in which the incorrect redshifts were listed on the images of the 5 LBGs whose images are plotted in Figure 5, was corrected by means of an `inner join` of the tables `results` and `results3`.