### PR TITLE
SP-2050: 02c notebook writes temp files in /tmp that can be avoided

### DIFF
--- a/DP0.2/02c_Image_Queries_with_TAP.ipynb
+++ b/DP0.2/02c_Image_Queries_with_TAP.ipynb
@@ -1397,9 +1397,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "hdulist = fits.open(image_url, cache=False)\n",
-    "for hdu in hdulist:\n",
-    "    print(hdu.name)"
+    "with fits.open(image_url, cache=False, use_fsspec=True) as hdulist:\n",
+    "    for hdu in hdulist:\n",
+    "        print(hdu.name)"
    ]
   },
   {
@@ -1710,9 +1710,9 @@
     "        dl_results = DatalinkResults.from_result_url(result['access_url'],\n",
     "                                                     session=auth_session)\n",
     "        image_url = dl_results['access_url'][0]\n",
-    "        hdulist = fits.open(image_url, cache=False)\n",
-    "        img_hdr = hdulist[1].header\n",
-    "        img_wcs = WCS(img_hdr)\n",
+    "        with fits.open(image_url, cache=False, use_fsspec=True) as hdulist:\n",
+    "            img_hdr = hdulist[1].header\n",
+    "            img_wcs = WCS(img_hdr)\n",
     "        print(r, img_wcs.footprint_contains(targetCoord))\n",
     "        del dl_results, image_url, hdulist, img_hdr, img_wcs"
    ]


### PR DESCRIPTION
Following Tim's advice (see the Jira ticket), I have updated the calls to fits.open in NB02c to (1) use "fsspec" to read the fits files, and (2) do this in a context manager so it closes the file afterward.