### PR TITLE
Reliability score edits from Fed and Tatiana

### DIFF
--- a/DP1/200_Data_Products/201_Catalogs/201_5_DiaSource_table.ipynb
+++ b/DP1/200_Data_Products/201_Catalogs/201_5_DiaSource_table.ipynb
@@ -36,7 +36,7 @@
     "\n",
     "**Packages:** `lsst.rsp`, `lsst.daf.butler`\n",
     "\n",
-    "**Credit:** Originally developed by the Rubin Community Science team with feedback from Eric Bellm.\n",
+    "**Credit:** Originally developed by the Rubin Community Science team with feedback from Eric Bellm, Federica Bianco, and Tatiana Cuellar.\n",
     "Please consider acknowledging them if this notebook is used for the preparation of journal articles, software releases, or other notebooks.\n",
     "\n",
     "**Get Support:**\n",
@@ -417,7 +417,7 @@
     "\n",
     "* `reliability`\n",
     "\n",
-    "The purpose of the `reliability` score in the `DiaSource` table is to provide a threshold measure to improve the purity of transient detections. This score is computed using information from the source and image characterization, as well as the information on the Telescope and Camera system. However, given that the reliability score model was trained on a relatively small and limited dataset, some caution is warranted in interpreting the `reliability` score in DP1, in particular for variable stars. Significant improvements are expected on future releases with LSSTCam data."
+    "The purpose of the `reliability` score in the `DiaSource` table is to provide a threshold measure to improve the purity of DIA detections. This score is computed using information from the source and image characterization, as well as the information on the Telescope and Camera system. However, given that the reliability score model was trained on a relatively small and limited dataset, some caution is warranted in interpreting the `reliability` score in DP1, in particular for variable stars. Significant improvements are expected on future releases with LSSTCam data."
    ]
   },
   {


### PR DESCRIPTION
Edited reliability score description making it more broad saying it's applicable to purity of DIA detections instead of just transients.

Adding Fed and Tatiana to credits.