### PR TITLE
Update 105_3 to work with newer weeklies

### DIFF
--- a/DP1/100_How_to_Use_RSP_Tools/105_Image_reprocessing/105_3_Forced_Photometry.ipynb
+++ b/DP1/100_How_to_Use_RSP_Tools/105_Image_reprocessing/105_3_Forced_Photometry.ipynb
@@ -19,7 +19,7 @@
     "Data Release: <a href=\"https://dp1.lsst.io/\">Data Preview 1</a> <br>\n",
     "Container Size: large <br>\n",
     "LSST Science Pipelines version: Release r29.1.1 <br>\n",
-    "Last verified to run: 2025-06-20 <br>\n",
+    "Last verified to run: 2025-08-28 <br>\n",
     "Repository: <a href=\"https://github.com/lsst/tutorial-notebooks\">github.com/lsst/tutorial-notebooks</a> <br>"
    ]
   },
@@ -83,6 +83,7 @@
    "outputs": [],
    "source": [
     "import numpy as np\n",
+    "import astropy.units as u\n",
     "from lsst.daf.butler import Butler\n",
     "from lsst.pipe.tasks.measurementDriver import (\n",
     "    ForcedMeasurementDriverConfig,\n",
@@ -224,6 +225,25 @@
   },
   {
    "cell_type": "markdown",
+   "id": "25a36031-e614-4cf0-a2fd-9197196150cb",
+   "metadata": {},
+   "source": [
+    "The forced measurement driver requires the input coordinates to have units attached. Attach units to the RA, Dec columns."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "76cd8d9f-d354-4c3c-a042-5707fc25e1e7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "table['coord_ra'].unit = u.degree\n",
+    "table['coord_dec'].unit = u.degree"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "0abd209b-d6b2-4ec5-95d5-7171bb1465fc",
    "metadata": {},
    "source": [
@@ -331,14 +351,6 @@
     "\n",
     "This functionality is limited to a handful of measurement plugins (for example, model-fitting algorithms will not work with this task because they require more ancillary information than it is set up to receive). Nonetheless, it offers a quick and easy way to extract measurements at arbitrary positions."
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "b1f77da3-481b-4cf3-9466-eefff1a43bbf",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {


### PR DESCRIPTION
Recent changes to ForcedMeasurementDriverTask require the input Astropy Table to have units attached to the RA, Dec coordinates, which it previously did not. This change adds units to the table columns. I have confirmed that the updated version works in the most recent weekly (w_2025_34), but also still works fine in the recommended version (r29.1.1).