### PR TITLE
Update mobu.yaml to exclude DP02_03c

### DIFF
--- a/mobu.yaml
+++ b/mobu.yaml
@@ -1,5 +1,8 @@
 exclude_dirs:
   - "DP0.2/11_User_Packages"
   - "DP0.2/19a_Introduction_to_AI"
-  - "DP0.2/03c_Big_deepCoadd_Cutout.ipynb"
   - "MPC"
+collection_rules:
+  - type: exclude_union_of
+    patterns:
+      - "DP0.2/03c_Big_deepCoadd_Cutout.ipynb"


### PR DESCRIPTION
DP0.2 notebook 03c is failing mobu checks due to an API change that we don't have a way to work around. This will exclude it from mobu checks.