### PR TITLE
Update mobu.yaml to exclude DP1 NB 204.4

### DIFF
--- a/mobu.yaml
+++ b/mobu.yaml
@@ -6,3 +6,4 @@ collection_rules:
   - type: exclude_union_of
     patterns:
       - "DP0.2/03c_Big_deepCoadd_Cutout.ipynb"
+      - "DP1/200_Data_Products/204_4_Bandpasses.ipynb"


### PR DESCRIPTION
The standard_passband datasets aren't in the DP1 Butler repo at data-int, so mobu fails for notebook 204.4. Exclude that notebook from the mobu checks.