### PR TITLE
Un-exclude tutorial 204.4 from mobu

### DIFF
--- a/mobu.yaml
+++ b/mobu.yaml
@@ -6,4 +6,3 @@ collection_rules:
   - type: exclude_union_of
     patterns:
       - "DP0.2/03c_Big_deepCoadd_Cutout.ipynb"
-      - "DP1/200_Data_Products/204_Calibrations/204_4_Bandpasses.ipynb"


### PR DESCRIPTION
Tutorial 204.4 was previously failing on `data-int` because of an issue with the `standard_passband` datasets on that environment.

The `standard_passband` datasets are now included in the `LSSTComCam/DP1` collection chain on `data-int`, so the tutorial should now pass on all environments.