### PR TITLE
SP-2358: NB 105_3, 105_4, 305_1 potential updates

### DIFF
--- a/DP1/100_How_to_Use_RSP_Tools/105_Image_reprocessing/105_3_Forced_Photometry.ipynb
+++ b/DP1/100_How_to_Use_RSP_Tools/105_Image_reprocessing/105_3_Forced_Photometry.ipynb
@@ -22,7 +22,7 @@
     "Data Release: <a href=\"https://dp1.lsst.io/\">Data Preview 1</a> <br>\n",
     "Container Size: large <br>\n",
     "LSST Science Pipelines version: r29.2.0 <br>\n",
-    "Last verified to run: 2025-09-30 <br>\n",
+    "Last verified to run: 2025-11-03 <br>\n",
     "Repository: <a href=\"https://github.com/lsst/tutorial-notebooks\">github.com/lsst/tutorial-notebooks</a> <br>"
    ]
   },
@@ -617,6 +617,14 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "90e0d3b6-4761-4466-922e-bcb6be1188c1",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "52f7fbda-0fde-4e72-93de-d9707dbdb1e8",
    "metadata": {},
    "outputs": [],
    "source": []

--- a/DP1/100_How_to_Use_RSP_Tools/105_Image_reprocessing/105_4_Synthetic_Source_Injection.ipynb
+++ b/DP1/100_How_to_Use_RSP_Tools/105_Image_reprocessing/105_4_Synthetic_Source_Injection.ipynb
@@ -22,7 +22,7 @@
     "Data Release: <a href=\"https://dp1.lsst.io/\">Data Preview 1</a> <br>\n",
     "Container Size: large <br>\n",
     "LSST Science Pipelines version: r29.2.0 <br>\n",
-    "Last verified to run: 2025-09-30 <br>\n",
+    "Last verified to run: 2025-11-03 <br>\n",
     "Repository: <a href=\"https://github.com/lsst/tutorial-notebooks\">github.com/lsst/tutorial-notebooks</a> <br>"
    ]
   },

--- a/DP1/300_Science_Demos/305_Galactic_variables_and_transients/305_1_Variable_star_light_curves.ipynb
+++ b/DP1/300_Science_Demos/305_Galactic_variables_and_transients/305_1_Variable_star_light_curves.ipynb
@@ -22,7 +22,7 @@
     "Data Release: <a href=\"https://dp1.lsst.io/\">Data Preview 1</a> <br>\n",
     "Container Size: large <br>\n",
     "LSST Science Pipelines version: r29.2.0 <br>\n",
-    "Last verified to run: 2025-09-30 <br>\n",
+    "Last verified to run: 2025-11-03 <br>\n",
     "Repository: <a href=\"https://github.com/lsst/tutorial-notebooks\">github.com/lsst/tutorial-notebooks</a> <br>"
    ]
   },


### PR DESCRIPTION
Made the following updates:

NB 105_3 (Forced Photometry):
- add a section showing forced measurement on visit images
- add comparisons of forced PSF measurements to those from Object/Source table 
- add a function to rename the flux and fluxErr columns to avoid confusion
- add more explanation of the columns that are returned by the task

NB 105_4:
- remove commented cells and unnecessary color imports

NB 305_1:
- add Carlin+2025 link
- filter negative fluxes before converting to mag