### PR TITLE
Exclude DP1 NBs 103_6 and 103_7 from mobu.yaml

### DIFF
--- a/mobu.yaml
+++ b/mobu.yaml
@@ -6,3 +6,5 @@ collection_rules:
   - type: exclude_union_of
     patterns:
       - "DP0.2/03c_Big_deepCoadd_Cutout.ipynb"
+      - "DP1/100_How_to_Use_RSP_Tools/103_Image_access_and_display/103_6_Color_Composite_Image.ipynb"
+      - "DP1/100_How_to_Use_RSP_Tools/103_Image_access_and_display/103_7_Big_deep_coadd_cutout.ipynb"


### PR DESCRIPTION
These two notebooks have the same failing use of a changed argument in GetTemplateTask that was the reason for excluding DP0.2/03c.