### PR TITLE
mlg-patch: add deprecation warning to commissioning 101 tutorial

### DIFF
--- a/Commissioning/101_lsstcam_visits_database.ipynb
+++ b/Commissioning/101_lsstcam_visits_database.ipynb
@@ -21,7 +21,7 @@
     "For the Rubin Science Platform at data.lsst.cloud.\\\n",
     "Container Size: Large\\\n",
     "LSST Science Pipelines version: v29.2.0\\\n",
-    "Last verified to run: 2026-01-28\\\n",
+    "Last verified to run: 2026-04-16\\\n",
     "Repository: <a href=\"https://github.com/lsst/tutorial-notebooks\">github.com/lsst/tutorial-notebooks</a>\\\n",
     "DOI: <a href=\"https://doi.org/10.11578/rubin/dc.20250909.20\">10.11578/rubin/dc.20250909.20</a>"
    ]
@@ -44,6 +44,17 @@
     "<a href=\"https://community.lsst.org/c/support\">Support Category</a> \n",
     "of the Rubin Community Forum.\n",
     "Rubin staff will respond to all questions posted there."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e41cccb2-c9ec-491b-ab3b-bc80e3a629ee",
+   "metadata": {},
+   "source": [
+    "<div class=\"alert alert-block alert-warning\">\n",
+    "<b>This tutorial notebook is superseded by \"DP2/102_Visit_and_tract_metadata\".</b><br>\n",
+    "    That DP2 notebook includes all visits and tracts that will be included in Data Preview 2, and should be used to make plots such as Figure 1, below.\n",
+    "</div>"
    ]
   },
   {


### PR DESCRIPTION
But still keep it. We'll take away the whole Commissioning folder later once all NBs are reproduced in other folders.