### PR TITLE
mlg 2026-05-27: fix PZ NB 310 1 to run

### DIFF
--- a/DP1/300_Science_Demos/310_Photometric_redshifts/310_1_Photoz_access.ipynb
+++ b/DP1/300_Science_Demos/310_Photometric_redshifts/310_1_Photoz_access.ipynb
@@ -22,7 +22,7 @@
     "Data Release: <a href=\"https://dp1.lsst.io/\">Data Preview 1</a> <br>\n",
     "Container Size: Large <br>\n",
     "LSST Science Pipelines version: Release r29.2.0 <br>\n",
-    "Last verified to run: 2025-09-07 <br>\n",
+    "Last verified to run: 2026-05-27 <br>\n",
     "Repository: <a href=\"https://github.com/lsst/tutorial-notebooks\">github.com/lsst/tutorial-notebooks</a> <br>"
    ]
   },
@@ -192,7 +192,7 @@
    "id": "016f2de7-84f9-4bee-aa2c-4f5b73159af2",
    "metadata": {},
    "source": [
-    "Open the read-only LSDB PZ catalog, which has been added by Rubin staff to the `/rubin` directory."
+    "Open the read-only LSDB PZ catalog, which has been added by Rubin staff to the `/rubin` directory. This notebook works with the originally released PZ data, which is now in the folder titled `object_photoz_old`."
    ]
   },
   {
@@ -202,7 +202,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "pz_cat = lsdb.open_catalog(\"/rubin/lsdb_data/object_photoz\")"
+    "dir_name = \"object_photoz_old\"\n",
+    "pz_cat = lsdb.open_catalog(\"/rubin/lsdb_data/\" + dir_name)"
    ]
   },
   {
@@ -535,7 +536,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "pz_cat = lsdb.open_catalog(\"/rubin/lsdb_data/object_photoz\",\n",
+    "pz_cat = lsdb.open_catalog(\"/rubin/lsdb_data/\" + dir_name,\n",
     "                           columns=use_columns)"
    ]
   },


### PR DESCRIPTION
Looks like the PZ files were changed, causing NB to fail, yet somehow this never triggered mobu. "Fix" is just to use the "old" PZ files, for now.