### PR TITLE
Update LSDB DP1 paths; update deprecated syntax to view nested subcols

### DIFF
--- a/DP1/100_How_to_Use_RSP_Tools/102_Catalog_access/102_5_LSDB_data_access.ipynb
+++ b/DP1/100_How_to_Use_RSP_Tools/102_Catalog_access/102_5_LSDB_data_access.ipynb
@@ -131,7 +131,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "base_path = UPath(\"/rubin/lsdb_data\")"
+    "base_path = UPath(\"/rubin/lsdb_data/dp1\")"
    ]
   },
   {
@@ -147,7 +147,7 @@
    "id": "dbe24ce4-ca74-4edb-8a33-a0689cefe8eb",
    "metadata": {},
    "source": [
-    "The four LSDB DP1 read-only catalogs available in the Rubin Science Platform at `data.lsst.cloud` are located in the directory `/rubin/lsdb_data`, and their names are:\n",
+    "The four LSDB DP1 read-only catalogs available in the Rubin Science Platform at `data.lsst.cloud` are located in the directory `/rubin/lsdb_data/dp1`, and their names are:\n",
     "\n",
     "- `object_collection`: the `Object` table\n",
     "- `object_collection_lite`: a limited number of columns from the `Object` table\n",
@@ -548,7 +548,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# object_cat[\"objectForcedSource\"].nest.fields"
+    "# object_cat[\"objectForcedSource\"].dtype.column_dtypes"
    ]
   },
   {
@@ -840,7 +840,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# dia_object_cat[\"diaSource\"].nest.fields"
+    "# dia_object_cat[\"diaSource\"].dtype.column_dtypes"
    ]
   },
   {
@@ -850,7 +850,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# dia_object_cat[\"diaObjectForcedSource\"].nest.fields"
+    "# dia_object_cat[\"diaObjectForcedSource\"].dtype.column_dtypes"
    ]
   },
   {


### PR DESCRIPTION
The LSDB team will be:
- serving DP2 catalogs from `/rubin/lsdb_data` 
- moving DP1 catalogs to `/rubin/lsdb_data/dp1`

Updating DP1 paths to reflect this change.

> *Note: we have created a symlink pointing `/rubin/lsdb_data/dp1` to `/rubin/lsdb_data` until the DP2 release, so these paths are already valid!*

In addition, this PR updates some now-deprecated syntax for viewing nested subcolumns (`my_cat.nest.fields` → `my_cat.dtype.column_dtypes`)

---

Edit: I believe the Mobu CI is failing because I opened this from a fork; however, I do not have write access to this repo