### PR TITLE
DM-55532: Exclude known failing tutorial from mobu

### DIFF
--- a/mobu.yaml
+++ b/mobu.yaml
@@ -9,3 +9,4 @@ collection_rules:
       - "DP0.2/03c_Big_deepCoadd_Cutout.ipynb"
       - "DP1/100_How_to_Use_RSP_Tools/103_Image_access_and_display/103_6_Color_Composite_Image.ipynb"
       - "DP1/100_How_to_Use_RSP_Tools/103_Image_access_and_display/103_7_Big_deep_coadd_cutout.ipynb"
+      - "DP1/200_Data_Products/206_Deblender_Products/206_2_Deblender_footprints.ipynb"


### PR DESCRIPTION
This notebook is expected to be broken, as the API changed and it was before we had dataset migrations in `scarlet_lite`.