### PR TITLE
DM-55532: Exclude all of DP0.2 from mobu

### DIFF
--- a/mobu.yaml
+++ b/mobu.yaml
@@ -1,4 +1,5 @@
 exclude_dirs:
+  - "DP0.2"
   - "DP0.2/11_User_Packages"
   - "DP0.2/19a_Introduction_to_AI"
   - "MPC"


### PR DESCRIPTION
We have decided these tutorials are not supported with the soon-to-be recommended, so stop running them under mobu.