### PR TITLE
DM-55553: Add a random suffix to the directory created in 105_6_Create_custom_coadd_images

### DIFF
--- a/DP1/100_How_to_Use_RSP_Tools/105_Image_reprocessing/105_6_Create_custom_coadd_images.ipynb
+++ b/DP1/100_How_to_Use_RSP_Tools/105_Image_reprocessing/105_6_Create_custom_coadd_images.ipynb
@@ -85,6 +85,8 @@
    "outputs": [],
    "source": [
     "import os\n",
+    "import shutil\n",
+    "import uuid\n",
     "from pathlib import Path\n",
     "from lsst.daf.butler import Butler\n",
     "from lsst.ctrl.mpexec import SimplePipelineExecutor\n",
@@ -590,7 +592,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "local_repo_path = Path(scratch_path, \"my_local_repo\")\n",
+    "local_repo_path = Path(scratch_path, f\"my_local_repo_{uuid.uuid4().hex}\")\n",
     "out_butler = executor.use_local_butler(local_repo_path)"
    ]
   },
@@ -770,7 +772,7 @@
    "outputs": [],
    "source": [
     "# %reset -f\n",
-    "# ! rm -r $SCRATCH_DIR/my_local_repo"
+    "# shutil.rmtree(local_repo_path, ignore_errors=True)"
    ]
   }
  ],


### PR DESCRIPTION
This change is needed because the temporary directory created is not fully deleted by the scratch purge process, which leads to the Butler instantiation process to assume that it is a valid Butler repo because the directory exists, even though the butler.yaml file has been deleted, and this causes mobu errors.

The fix here is to add a random suffix to the directory name so that each run is done on a clean directory.