### PR TITLE
SP-3305: implement TJs comments on Butler in tutorials

### DIFF
--- a/DP2/100_How_to_use_RSP_tools/101_Get_started/101_4_Remote_file_access_with_WebDAV.ipynb
+++ b/DP2/100_How_to_use_RSP_tools/101_Get_started/101_4_Remote_file_access_with_WebDAV.ipynb
@@ -21,8 +21,8 @@
     "For the Rubin Science Platform at data.lsst.cloud.\\\n",
     "Data Release: <a href=\"https://dp2.lsst.io\">Data Preview 2</a>\\\n",
     "Container Size: Small\\\n",
-    "LSST Science Pipelines version: r30.0.9\\\n",
-    "Last verified to run: 2026-07-19\\\n",
+    "LSST Science Pipelines version: r30.0.10\\\n",
+    "Last verified to run: 2026-07-23\\\n",
     "Repository: [github.com/lsst/tutorial-notebooks](https://github.com/lsst/tutorial-notebooks)\\\n",
     "DOI: [10.11578/rubin/dc.20250909.20](https://doi.org/10.11578/rubin/dc.20250909.20)"
    ]
@@ -68,7 +68,7 @@
    "source": [
     "### 1.1. Import packages\n",
     "\n",
-    "Import `os`, a python module for using the operating system ([os documentation](https://docs.python.org/3/library/os.html)), and `subprocess`, a python module for running command line functionality ([subprocess documentation](https://docs.python.org/3/library/subprocess.html))."
+    "Import `os`, a python module for using the operating system ([os documentation](https://docs.python.org/3/library/os.html))."
    ]
   },
   {
@@ -78,8 +78,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import os\n",
-    "import subprocess"
+    "import os"
    ]
   },
   {
@@ -101,7 +100,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "filename = os.getenv(\"HOME\") + \"/temp_webdav_tutorial.txt\"\n",
+    "filename = os.path.join(os.getenv(\"HOME\"), \"temp_webdav_tutorial.txt\")\n",
     "print(filename)"
    ]
   },
@@ -120,29 +119,30 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "fout = open(filename, 'w')\n",
-    "fout.write('# this is a temporary file \\n')\n",
-    "fout.write('hello world')\n",
-    "fout.close()"
+    "with open(filename, 'w') as fout:\n",
+    "    print('# this is a temporary file', file=fout)\n",
+    "    print('hello world', file=fout)"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "5886ff45-0548-4bf9-b488-7505c7ab4666",
+   "id": "5faa49e1-704b-4f6d-9aa2-7f95b8a693b1",
    "metadata": {},
    "source": [
-    "Use the `subprocess` module to run the Linux `cat` (concatenate) command on the newly created file. When run on the terminal command line, `cat` displays the contents of the file. When run with `subprocess` and `capture_output = True`, what would have been displayed in saved in `result`, and that standard output can then be displayed with `result.stdout`."
+    "Use the python `open` function to open the file and read its contents to confirm that it is as expected. Note that one could do the same check by running the Linux `cat` (concatenate) command on the terminal command line to display the file's contents to the terminal."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3a59fa8b-00e4-47e7-ab8f-3d887bc0d749",
+   "id": "57707e9a-ab62-46d9-a34a-9a6e36b51717",
    "metadata": {},
    "outputs": [],
    "source": [
-    "result = subprocess.run([\"cat\", filename], capture_output=True, text=True)\n",
-    "print(result.stdout)"
+    "with open(filename) as fin:\n",
+    "    file_contents = fin.read()\n",
+    "\n",
+    "print(file_contents)"
    ]
   },
   {
@@ -160,7 +160,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "del fout, result"
+    "del file_contents"
    ]
   },
   {
@@ -530,7 +530,7 @@
     "\n",
     "A warning might pop up, saying, e.g., that the document is on a volume that does not support permanent version storage. Click OK.\n",
     "\n",
-    "Rerun the `subprocess` to print the contents of the file and see that it has been updated."
+    "Rerun the `open` and `read` commands to print the contents of the file and see that it has been updated."
    ]
   },
   {
@@ -540,8 +540,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "result = subprocess.run([\"cat\", filename], capture_output=True, text=True)\n",
-    "print(result.stdout)"
+    "with open(filename) as fin:\n",
+    "    file_contents = fin.read()\n",
+    "\n",
+    "print(file_contents)"
    ]
   },
   {
@@ -585,13 +587,13 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# result = subprocess.run([\"rm\", filename])"
+    "# os.remove(filename)"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c74c4640-ea02-406a-932c-660fba160383",
+   "id": "956ca424-08b9-429c-b1ea-0aa76b528a46",
    "metadata": {},
    "outputs": [],
    "source": []

--- a/DP2/100_How_to_use_RSP_tools/103_Image_access_and_display/103_1_Butler_image_access.ipynb
+++ b/DP2/100_How_to_use_RSP_tools/103_Image_access_and_display/103_1_Butler_image_access.ipynb
@@ -118,7 +118,7 @@
    "source": [
     "## 2. Create an instance of the Butler\n",
     "\n",
-    "Use the `dafButler.Butler` function to instantiate a `butler` that is configured to access the Data Preview 2 (DP2) data release."
+    "Use the `Butler` function to instantiate a `butler` that is configured to access the Data Preview 2 (DP2) data release."
    ]
   },
   {
@@ -128,8 +128,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "butler = Butler(\"dp2\", collections=\"dp2\")\n",
-    "assert butler is not None"
+    "butler = Butler(\"dp2\", collections=\"dp2\")"
    ]
   },
   {

--- a/DP2/100_How_to_use_RSP_tools/104_Butler_data_access/104_1_Get_started_with_the_butler.ipynb
+++ b/DP2/100_How_to_use_RSP_tools/104_Butler_data_access/104_1_Get_started_with_the_butler.ipynb
@@ -138,7 +138,7 @@
    "source": [
     "## 2. Create an instance of the Butler\n",
     "\n",
-    "Use the `dafButler.Butler` function to instantiate a `butler` that is configured to access the Data Preview 2 (DP2) data release:\n",
+    "Use the `Butler` function to instantiate a `butler` that is configured to access the Data Preview 2 (DP2) data release:\n",
     "* repository `dp2`\n",
     "* collection `dp2`\n",
     "\n",
@@ -154,8 +154,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "butler = Butler(\"dp2\", collections=\"dp2\")\n",
-    "assert butler is not None"
+    "butler = Butler(\"dp2\", collections=\"dp2\")"
    ]
   },
   {

--- a/DP2/100_How_to_use_RSP_tools/104_Butler_data_access/104_3_Image_queries_with_the_butler.ipynb
+++ b/DP2/100_How_to_use_RSP_tools/104_Butler_data_access/104_3_Image_queries_with_the_butler.ipynb
@@ -21,8 +21,8 @@
     "For the Rubin Science Platform at data.lsst.cloud. <br>\n",
     "Data Release: <a href=\"https://dp2.lsst.io\">Data Preview 2</a> <br>\n",
     "Container Size: large <br>\n",
-    "LSST Science Pipelines version: r30.0.9 <br>\n",
-    "Last verified to run: 2026-07-20 <br>\n",
+    "LSST Science Pipelines version: r30.0.10 <br>\n",
+    "Last verified to run: 2026-07-23 <br>\n",
     "Repository: <a href=\"https://github.com/lsst/tutorial-notebooks\">github.com/lsst/tutorial-notebooks</a> <br>"
    ]
   },
@@ -436,9 +436,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "query = f\"patch.region OVERLAPS POINT({ra}, {dec})\"\n",
+    "query = \"patch.region OVERLAPS POINT(:ra, :dec)\"\n",
+    "bind_params = {\"ra\": ra, \"dec\": dec}\n",
     "dataset_refs = butler.query_datasets(\"deep_coadd\",\n",
-    "                                     where=query)\n",
+    "                                     where=query,\n",
+    "                                     bind=bind_params)\n",
     "print(len(dataset_refs))\n",
     "del query, dataset_refs"
    ]

--- a/DP2/100_How_to_use_RSP_tools/104_Butler_data_access/104_4_Catalog_queries_with_the_butler.ipynb
+++ b/DP2/100_How_to_use_RSP_tools/104_Butler_data_access/104_4_Catalog_queries_with_the_butler.ipynb
@@ -135,8 +135,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "butler = Butler(\"dp2\", collections=\"dp2\")\n",
-    "assert butler is not None"
+    "butler = Butler(\"dp2\", collections=\"dp2\")"
    ]
   },
   {
@@ -553,9 +552,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "query = f\"visit.region OVERLAPS POINT({ra}, {dec})\"\n",
+    "query = \"visit.region OVERLAPS POINT(:ra, :dec)\"\n",
+    "bind_params = {\"ra\": ra, \"dec\": dec}\n",
     "dataset_refs = butler.query_datasets(\"source\",\n",
-    "                                     where=query)\n",
+    "                                     where=query,\n",
+    "                                     bind=bind_params)\n",
     "print(len(dataset_refs))\n",
     "del query, dataset_refs"
    ]
@@ -575,9 +576,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "query = f\"patch.region OVERLAPS POINT({ra}, {dec})\"\n",
+    "query = \"patch.region OVERLAPS POINT(:ra, :dec)\"\n",
     "dataset_refs = butler.query_datasets(\"object\",\n",
-    "                                     where=query)\n",
+    "                                     where=query,\n",
+    "                                     bind=bind_params)\n",
     "print(len(dataset_refs))\n",
     "del query, dataset_refs"
    ]

--- a/DP2/200_Data_products/204_Calibrations/204_2_The_Monster.ipynb
+++ b/DP2/200_Data_products/204_Calibrations/204_2_The_Monster.ipynb
@@ -102,7 +102,7 @@
     "from astropy.time import Time\n",
     "\n",
     "import lsst.geom\n",
-    "import lsst.daf.butler as dafButler\n",
+    "from lsst.daf.butler import Butler\n",
     "from lsst.rsp import RSPDiscovery\n",
     "from lsst.meas.algorithms import ReferenceObjectLoader\n",
     "from lsst.rsp import get_tap_service"
@@ -131,7 +131,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "butler = dafButler.Butler(\"dp2\", collections=[\"dp2\"])"
+    "butler = Butler(\"dp2\", collections=[\"dp2\"])"
    ]
   },
   {

--- a/DP2/200_Data_products/204_Calibrations/204_3_Astrometric_calibration.ipynb
+++ b/DP2/200_Data_products/204_Calibrations/204_3_Astrometric_calibration.ipynb
@@ -111,7 +111,7 @@
     "import astropy.units as u\n",
     "from astropy.coordinates import SkyCoord\n",
     "\n",
-    "import lsst.daf.butler as dafButler\n",
+    "from lsst.daf.butler import Butler\n",
     "from lsst.images import SkyProjection, DetectorFrame, Box\n",
     "from lsst.utils.plotting import (get_multiband_plot_colors,\n",
     "                                 get_multiband_plot_linestyles)"
@@ -140,7 +140,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "butler = dafButler.Butler(\"dp2\", collections=\"dp2\")"
+    "butler = Butler(\"dp2\", collections=\"dp2\")"
    ]
   },
   {

--- a/DP2/300_Science_demos/305_Galactic_variables_and_transients/305_1_Variable_star_light_curves.ipynb
+++ b/DP2/300_Science_demos/305_Galactic_variables_and_transients/305_1_Variable_star_light_curves.ipynb
@@ -21,8 +21,8 @@
     "For the Rubin Science Platform at data.lsst.cloud.\\\n",
     "Data Release: [Data Preview 2](https://dp2.lsst.io)\\\n",
     "Container Size: Small\\\n",
-    "LSST Science Pipelines version: r30.0.9\\\n",
-    "Last verified to run: 2026-07-19\\\n",
+    "LSST Science Pipelines version: r30.0.10\\\n",
+    "Last verified to run: 2026-07-23\\\n",
     "Repository: [github.com/lsst/tutorial-notebooks](https://github.com/lsst/tutorial-notebooks)\\\n",
     "DOI: [10.11578/rubin/dc.20250909.20](https://doi.org/10.11578/rubin/dc.20250909.20)"
    ]
@@ -279,8 +279,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "query = \"SELECT fsodo.coord_ra, fsodo.coord_dec, \"\\\n",
-    "        \"fsodo.diaObjectId, fsodo.visit, fsodo.band, \"\\\n",
+    "query = \"SELECT fsodo.diaObjectId, fsodo.visit, fsodo.band, \"\\\n",
     "        \"fsodo.psfDiffFlux, fsodo.psfDiffFluxErr, \"\\\n",
     "        \"fsodo.psfFlux as psfFlux, fsodo.psfFluxErr, \"\\\n",
     "        \"fsodo.psfDiffFlux_flag, fsodo.diff_PixelFlags_nodataCenter, \"\\\n",

--- a/DP2/300_Science_demos/305_Galactic_variables_and_transients/305_2_Stellar_variability_characterization.ipynb
+++ b/DP2/300_Science_demos/305_Galactic_variables_and_transients/305_2_Stellar_variability_characterization.ipynb
@@ -21,8 +21,8 @@
     "For the Rubin Science Platform at data.lsst.cloud.\\\n",
     "Data Release: [Data Preview 2](https://dp2.lsst.io)\\\n",
     "Container Size: Small\\\n",
-    "LSST Science Pipelines version: r30.0.9\\\n",
-    "Last verified to run: 2026-07-19\\\n",
+    "LSST Science Pipelines version: r30.0.10\\\n",
+    "Last verified to run: 2026-07-23\\\n",
     "Repository: [github.com/lsst/tutorial-notebooks](https://github.com/lsst/tutorial-notebooks)\\\n",
     "DOI: [10.11578/rubin/dc.20250909.20](https://doi.org/10.11578/rubin/dc.20250909.20)"
    ]


### PR DESCRIPTION
- Updated butler imports to always use "Butler" rather than "dafButler".
- Updated a couple instances of using string joins to create file paths to os.path.join. There are likely others I didn't find, but we'll update them later.
- Changed a few butler queries to use bind parameters where appropriate.
- Updated 101_4 (webdav) to use context managers for opening and writing/reading files, removed the use of `subprocess` in favor of simpler python `open` methods.
- Fixed mis-statement in 202_1 re: .image planes not having WCS.
- Removed "coord_ra" and "coord_dec" from NB 305_1 ForcedSourceOnDiaObject queries.