### PR TITLE
SP-3307: implement JBs comments on 205 1 NB

### DIFF
--- a/DP2/200_Data_products/204_Calibrations/204_2_The_Monster.ipynb
+++ b/DP2/200_Data_products/204_Calibrations/204_2_The_Monster.ipynb
@@ -22,7 +22,7 @@
     "Data Release: [Data Preview 2](https://dp2.lsst.io/)\\\n",
     "Container Size: Large\\\n",
     "LSST Science Pipelines version: r30.0.10\\\n",
-    "Last verified to run: 2026-07-20\\\n",
+    "Last verified to run: 2026-07-23\\\n",
     "Repository: [github.com/lsst/tutorial-notebooks](https://github.com/lsst/tutorial-notebooks)\\\n",
     "DOI: [10.11578/rubin/dc.20250909.20](https://doi.org/10.11578/rubin/dc.20250909.20)"
    ]
@@ -525,11 +525,11 @@
    "outputs": [],
    "source": [
     "query = (\n",
-    "    \"SELECT coord_ra, coord_dec \"\n",
+    "    \"SELECT ra, dec \"\n",
     "    \"FROM dp2.Source \"\n",
     "    f\"WHERE visit = {visit_id} \"\n",
     "    \"AND calib_psf_used = 1 \"\n",
-    "    \"AND CONTAINS(POINT('ICRS', coord_ra, coord_dec), \"\n",
+    "    \"AND CONTAINS(POINT('ICRS', ra, dec), \"\n",
     "    f\"CIRCLE('ICRS', {ra_cen}, {dec_cen}, {radius})) = 1\"\n",
     ")\n",
     "job = service.submit_job(query)\n",
@@ -549,8 +549,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "source_ra = np.asarray(source_table['coord_ra'])\n",
-    "source_dec = np.asarray(source_table['coord_dec'])\n",
+    "source_ra = np.asarray(source_table['ra'])\n",
+    "source_dec = np.asarray(source_table['dec'])\n",
     "print(len(source_ra))"
    ]
   },

--- a/DP2/200_Data_products/205_Point_spread_function/205_1_PSF_for_deep_coadd_images.ipynb
+++ b/DP2/200_Data_products/205_Point_spread_function/205_1_PSF_for_deep_coadd_images.ipynb
@@ -22,7 +22,7 @@
     "Data Release: [Data Preview 2](https://dp2.lsst.io/)\\\n",
     "Container Size: Large\\\n",
     "LSST Science Pipelines version: r30.0.10\\\n",
-    "Last verified to run: 2026-07-22\\\n",
+    "Last verified to run: 2026-07-23\\\n",
     "Repository: [github.com/lsst/tutorial-notebooks](https://github.com/lsst/tutorial-notebooks)\\\n",
     "DOI: [10.11578/rubin/dc.20250909.20](https://doi.org/10.11578/rubin/dc.20250909.20)"
    ]
@@ -59,7 +59,7 @@
     "This notebook demonstrates how to visualize the PSF model of a `deep_coadd` at a particular location, and how to explore the PSF model methods to calculate and visualize its properties.\n",
     "The final section shows an example of PSF model residual visualization.\n",
     "\n",
-    "In DP2, a `deep_coadd` is stored in the new `lsst.images` data model as a `CellCoadd` object. Its PSF is accessed through the `deep_coadd.psf` attribute, and its astrometric solution through `deep_coadd.sky_projection` (see the DP2 tutorial on `deep_coadd` images and astrometric calibration).\n",
+    "In DP2, a `deep_coadd` is stored in the new `lsst.images` data model as a `CellCoadd` object. Its PSF is accessed through the `deep_coadd.psf` attribute, and its astrometric mapping through `deep_coadd.sky_projection` (see the DP2 tutorial on `deep_coadd` images and astrometric calibration).\n",
     "The PSF modeling was performed with the [\"PSF in the Full Field of View\"](https://ui.adsabs.harvard.edu/abs/2021ascl.soft02024J/abstract) (PIFF) software; the coadd PSF is a position-dependent weighted sum of the contributing single-visit PSF models.\n",
     "\n",
     "The new PSF object provides `compute_kernel_image` and `compute_stellar_image` methods.\n",
@@ -253,8 +253,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "query = f\"band.name='{my_band}' AND patch.region OVERLAPS POINT({ra_cen}, {dec_cen})\"\n",
-    "dataset_refs = butler.query_datasets(\"deep_coadd\", where=query)\n",
+    "query = f\"band.name=:band AND patch.region OVERLAPS POINT(:ra, :dec)\"\n",
+    "bind_params = {'band':my_band, 'ra':ra_cen, 'dec':dec_cen}\n",
+    "\n",
+    "dataset_refs = butler.query_datasets(\"deep_coadd\", where=query,\n",
+    "                                     bind=bind_params)\n",
     "deep_coadd = butler.get(dataset_refs[0])\n",
     "deep_coadd"
    ]
@@ -432,7 +435,7 @@
    "source": [
     "### 3.2. PSF size and shape with GalSim HSM\n",
     "\n",
-    "An independent way to characterize the PSF size and shape is with adaptive moments, using the HSM algorithm ([Hirata & Seljak 2003](https://ui.adsabs.harvard.edu/abs/2003MNRAS.343..459H/abstract); [Mandelbaum et al. 2005](https://ui.adsabs.harvard.edu/abs/2005MNRAS.361.1287M/abstract)) as implemented in [GalSim](https://github.com/GalSim-developers/GalSim). `galsim.hsm.FindAdaptiveMom` fits an elliptical Gaussian to the image and returns the adaptive-moments size `moments_sigma` (the determinant radius $|\\det M|^{1/4}$, in pixels) and the `observed_shape` (a `Shear` with ellipticity components `e1` and `e2`)."
+    "An independent way to characterize the PSF size and shape is with adaptive moments, using the HSM algorithm ([Hirata & Seljak 2003](https://ui.adsabs.harvard.edu/abs/2003MNRAS.343..459H/abstract); [Mandelbaum et al. 2005](https://ui.adsabs.harvard.edu/abs/2005MNRAS.361.1287M/abstract)) as implemented in [GalSim](https://github.com/GalSim-developers/GalSim). `galsim.hsm.FindAdaptiveMom` fits an elliptical Gaussian to the image and returns the adaptive-moments size `moments_sigma` (the determinant radius $|\\det M|^{1/4}$, in pixels) and the `observed_shape` (a `Shear` with ellipticity components `e1` and `e2`). The HSM algorithm is the same algorithm that is used to measure PSF moments that are tabulated in various DP2 catalogs."
    ]
   },
   {
@@ -487,40 +490,22 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d91387cc",
-   "metadata": {},
-   "source": [
-    "Compute the center of the PSF image from its dimensions."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "7ba9af6d",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "center_pix = np.array([xlen / 2, ylen / 2])"
-   ]
-  },
-  {
-   "cell_type": "markdown",
    "id": "88ca3c8f",
    "metadata": {},
    "source": [
-    "Create a coordinate grid and calculate the distance from each pixel to the center."
+    "Create a coordinate grid and calculate the distance from each pixel to the center. Using the `meshgrid` method associated with the psf bbox retrieves coordinates with (0, 0) at the center of the kernel image."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f7ca37fb",
+   "id": "d74a40fd-6560-41f8-8fd7-3e40e9633cc4",
    "metadata": {},
    "outputs": [],
    "source": [
-    "yy, xx = np.indices((ylen, xlen))\n",
+    "xx, yy = psf_kernel_image.bbox.meshgrid()\n",
     "coords = np.stack((xx, yy), axis=-1)\n",
-    "distances = np.linalg.norm(coords - center_pix, axis=-1)"
+    "distances = np.linalg.norm(coords, axis=-1)"
    ]
   },
   {
@@ -1038,6 +1023,22 @@
    "source": [
     "> **Figure 6:** Measured star used for PSF modeling (left), PSF model (center), and residuals (right)."
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4fcf988d-c407-449b-8d96-0b9f1b1cbd00",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "843d80a4-3227-41f9-93a9-29420319e7cc",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {


### PR DESCRIPTION
- Reworded "astrometric solution" to "astrometric mapping"
- Added reminder that HSM moments are used throughout the DP2 catalogs
- Fixed coords of radial profile calculation
- Update NB 204_2 to use ra, dec instead of coord_ra, coord_dec when querying Source table.